### PR TITLE
Handle start token selection in decoding

### DIFF
--- a/src/decoding/base.py
+++ b/src/decoding/base.py
@@ -1,6 +1,19 @@
 # src/decoding/base.py
 import torch
 
+
+def _select_start_token_id(tok, eot_id=None):
+    start_id = tok.token_to_id("<SOT>")
+    if start_id is None:
+        if eot_id is None:
+            eot_id = tok.token_to_id("<EOT>")
+        start_id = eot_id if eot_id is not None else tok.pad_id
+    if start_id is None:
+        raise ValueError(
+            "Tokenizer must define at least one start token among <SOT>, <EOT> or the pad token."
+        )
+    return start_id
+
 @torch.no_grad()
 def greedy_decode(model, tok, input_text: str, max_new_tokens=128, device="cpu"):
     """
@@ -13,7 +26,7 @@ def greedy_decode(model, tok, input_text: str, max_new_tokens=128, device="cpu")
     inp = torch.tensor([tok.encode(input_text)], dtype=torch.long, device=device)
     att = (inp != pad_id)
     # seed decoder: usa <SOT> se esiste, altrimenti <EOT> o <pad>
-    start_id = tok.token_to_id("<SOT>") or eot_id or pad_id
+    start_id = _select_start_token_id(tok, eot_id)
     y = torch.tensor([[start_id]], dtype=torch.long, device=device)
 
     for _ in range(max_new_tokens):
@@ -27,4 +40,7 @@ def greedy_decode(model, tok, input_text: str, max_new_tokens=128, device="cpu")
 @torch.no_grad()
 def decode_to_text(model, tok, input_text, **kw):
     ids = greedy_decode(model, tok, input_text, **kw)
+    start_id = _select_start_token_id(tok)
+    if ids and ids[0] == start_id:
+        ids = ids[1:]
     return tok.tk.decode(ids)

--- a/tests/test_decoding.py
+++ b/tests/test_decoding.py
@@ -1,0 +1,52 @@
+import sys
+from pathlib import Path
+
+import torch
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from src.decoding.base import decode_to_text, greedy_decode
+
+
+class DummyModel:
+    def eval(self):
+        pass
+
+    def __call__(self, inp, att, decoder_input_ids):
+        seq_len = decoder_input_ids.shape[1]
+        vocab_size = 3
+        logits = torch.full((1, seq_len, vocab_size), -1e9, dtype=torch.float)
+        logits[:, -1, 2] = 0  # force <EOT>
+        return {"logits": logits}
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self.pad_id = 1
+        self.tk = self
+        self.decoded = None
+
+    def encode(self, text):
+        return [5]
+
+    def token_to_id(self, token):
+        mapping = {"<SOT>": 0, "<EOT>": 2}
+        return mapping.get(token, None)
+
+    def decode(self, ids):
+        self.decoded = ids
+        return "decoded"
+
+
+def test_greedy_decode_uses_start_token_and_strips_on_decode():
+    model = DummyModel()
+    tok = DummyTokenizer()
+
+    ids = greedy_decode(model, tok, "prompt", max_new_tokens=2)
+
+    assert ids[0] == 0
+
+    text = decode_to_text(model, tok, "prompt", max_new_tokens=2)
+
+    assert tok.decoded == [2]
+    assert text == "decoded"


### PR DESCRIPTION
## Summary
- ensure greedy decoding selects an explicit start token and raises when unavailable
- strip the start token from text reconstruction
- add a unit test covering start token selection and decoding

## Testing
- pytest tests/test_decoding.py

------
https://chatgpt.com/codex/tasks/task_e_68e0412f03288331a18b730e4e915f55