### PR TITLE
Compute steps per epoch from dataset size

### DIFF
--- a/configs/train/baseline.yaml
+++ b/configs/train/baseline.yaml
@@ -13,11 +13,11 @@ max_len: 256
 
 # training
 batch_size: 16
+num_epochs: 10
+gradient_accumulation_steps: 1
 lr: 3e-4
 weight_decay: 0.01
 warmup_steps: 2000
-max_steps: 30000
-eval_every: 1000
 save_dir: "checkpoints/baseline"
 seed: 42
 

--- a/configs/train/mix_3322.yaml
+++ b/configs/train/mix_3322.yaml
@@ -30,11 +30,11 @@ max_len: 512
 
 # training
 batch_size: 16
+num_epochs: 10
+gradient_accumulation_steps: 1
 lr: 3e-4
 weight_decay: 0.01
 warmup_steps: 2000
-max_steps: 30000
-eval_every: 1000
 save_dir: "checkpoints/mix3322"
 seed: 42
 device: "cuda"

--- a/configs/train/rope_on.yaml
+++ b/configs/train/rope_on.yaml
@@ -1,0 +1,27 @@
+# Ablation config: identical to baseline but reserved for RoPE positional encodings.
+train_file: "data/processed/text2rdf.train.jsonl"
+val_file: "data/processed/text2rdf.val.jsonl"
+tokenizer_file: "data/vocab/bpe.json"
+
+# modello
+use_rope: true  # placeholder flag for future experiments
+d_model: 384
+nhead: 6
+enc_layers: 3
+dec_layers: 3
+ff_dim: 1536
+dropout: 0.1
+max_len: 256
+
+# training
+batch_size: 16
+num_epochs: 10
+gradient_accumulation_steps: 1
+lr: 3e-4
+weight_decay: 0.01
+warmup_steps: 2000
+save_dir: "checkpoints/rope_on"
+seed: 42
+
+device: "cuda"
+num_workers: 4

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -1,5 +1,6 @@
-import os, torch
-from tqdm import tqdm
+import math
+import os
+import torch
 from contextlib import nullcontext
 from inspect import signature
 
@@ -24,10 +25,22 @@ def evaluate(model, dataloader, device, pad_id):
         att = batch["attention_mask"].to(device, non_blocking=True)
         lab = batch["labels"].to(device, non_blocking=True)
         out = model(inp, att, labels=lab)
-        tot += out["loss"].item(); n += 1
+        tot += out["loss"].item()
+        n += 1
     return tot / max(1, n)
 
-def train_loop(model, train_dl, val_dl, cfg, device, pad_id):
+
+def train_loop(
+    model,
+    train_dl,
+    val_dl,
+    cfg,
+    device,
+    pad_id,
+    steps_per_epoch,
+    *,
+    max_train_steps=0,
+):
     opt = torch.optim.AdamW(model.parameters(), lr=cfg["lr"], weight_decay=cfg["weight_decay"])
 
     # ✅ nuove API (evita i FutureWarning)
@@ -58,48 +71,121 @@ def train_loop(model, train_dl, val_dl, cfg, device, pad_id):
     torch.backends.cudnn.benchmark = True if device == "cuda" else False
 
     os.makedirs(cfg["save_dir"], exist_ok=True)
-    step, best_val = 0, float("inf")
-    pbar = tqdm(total=cfg["max_steps"], desc="train")
-    model.train()
 
-    while step < cfg["max_steps"]:
-        for batch in train_dl:
-            step += 1
-            lr_scale = cosine_with_warmup(step, cfg["warmup_steps"], cfg["max_steps"])
-            for pg in opt.param_groups: pg["lr"] = cfg["lr"] * lr_scale
+    steps_per_epoch = max(1, int(steps_per_epoch))
+    num_epochs = int(cfg["num_epochs"])
+    grad_accum = max(1, int(cfg.get("gradient_accumulation_steps", 1)))
+    optimizer_steps_per_epoch = math.ceil(steps_per_epoch / grad_accum)
+    warmup_steps = int(cfg.get("warmup_steps", 0))
 
+    max_train_steps = int(max_train_steps or 0)
+    total_optimizer_steps = max(1, num_epochs * optimizer_steps_per_epoch)
+    if max_train_steps > 0:
+        total_optimizer_steps = min(total_optimizer_steps, max_train_steps)
+
+    global_step = 0
+    best_val = float("inf")
+    best_epoch = 0
+    best_step = 0
+
+    stop_training = False
+
+    for epoch in range(num_epochs):
+        model.train()
+        opt.zero_grad(set_to_none=True)
+        running_loss = 0.0
+        epoch_bar = tqdm(
+            enumerate(train_dl, start=1),
+            total=steps_per_epoch,
+            desc=f"epoch {epoch + 1}/{num_epochs}",
+            leave=False,
+        )
+
+        for batch_idx, batch in epoch_bar:
             inp = batch["input_ids"].to(device, non_blocking=True)
             att = batch["attention_mask"].to(device, non_blocking=True)
             lab = batch["labels"].to(device, non_blocking=True)
 
-            opt.zero_grad(set_to_none=True)
-            
             with autocast_ctx:
                 out = model(inp, att, labels=lab)
                 loss = out["loss"]
 
+            loss_to_backward = loss / grad_accum
             if scaler is not None:
-                scaler.scale(loss).backward()
-                torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
-                scaler.step(opt)
-                scaler.update()
+                scaler.scale(loss_to_backward).backward()
             else:
-                loss.backward()
+                loss_to_backward.backward()
+
+            running_loss += loss.item()
+
+            perform_step = (batch_idx % grad_accum == 0) or (batch_idx == steps_per_epoch)
+            if perform_step:
+                if scaler is not None:
+                    scaler.unscale_(opt)
                 torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
-                opt.step()
 
-            pbar.set_postfix({"loss": f"{loss.item():.3f}", "lr": f"{pg['lr']:.2e}"})
-            pbar.update(1)
+                global_step += 1
+                lr_scale = cosine_with_warmup(
+                    global_step,
+                    warmup_steps,
+                    total_optimizer_steps,
+                )
+                for pg in opt.param_groups:
+                    pg["lr"] = cfg["lr"] * lr_scale
 
-            if step % cfg["eval_every"] == 0 or step == cfg["max_steps"]:
-                val = evaluate(model, val_dl, device, pad_id)
-                torch.save({"model": model.state_dict(), "config": cfg},
-                           os.path.join(cfg["save_dir"], f"step{step}_valloss{val:.3f}.pt"))
-                if val < best_val:
-                    best_val = val
-                    torch.save({"model": model.state_dict(), "config": cfg},
-                               os.path.join(cfg["save_dir"], "best.pt"))
-                model.train()
-            if step >= cfg["max_steps"]: break
-    pbar.close()
-    return best_val
+                if scaler is not None:
+                    scaler.step(opt)
+                    scaler.update()
+                else:
+                    opt.step()
+                opt.zero_grad(set_to_none=True)
+
+                if max_train_steps and global_step >= max_train_steps:
+                    stop_training = True
+
+            current_lr = opt.param_groups[0]["lr"]
+            avg_loss = running_loss / batch_idx
+            epoch_bar.set_postfix({
+                "loss": f"{avg_loss:.3f}",
+                "lr": f"{current_lr:.2e}",
+                "step": global_step,
+            })
+
+            if batch_idx >= steps_per_epoch or stop_training:
+                break
+
+        epoch_bar.close()
+
+        val = evaluate(model, val_dl, device, pad_id)
+        ckpt = {
+            "model": model.state_dict(),
+            "config": cfg,
+            "epoch": epoch + 1,
+            "global_step": global_step,
+            "val_loss": val,
+            "optimizer": opt.state_dict(),
+        }
+        if scaler is not None:
+            ckpt["scaler"] = scaler.state_dict()
+        torch.save(ckpt, os.path.join(cfg["save_dir"], f"epoch{epoch + 1:03d}.pt"))
+        if val < best_val:
+            best_val = val
+            best_epoch = epoch + 1
+            best_step = global_step
+            torch.save(ckpt, os.path.join(cfg["save_dir"], "best.pt"))
+
+        model.train()
+        tqdm.write(
+            f"[epoch {epoch + 1}] val loss: {val:.3f} | best: {best_val:.3f}"
+            f" @ step {best_step}"
+        )
+
+        if stop_training:
+            break
+
+    return {
+        "best_val": best_val,
+        "best_epoch": best_epoch,
+        "best_step": best_step,
+        "global_step": global_step,
+    }


### PR DESCRIPTION
## Summary
- add explicit training hyperparameters to the RoPE ablation config
- derive the epoch batch count from the dataset size in `cmd_train` and guard against empty datasets

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68e03ee30e008331acdff23d309585fa