### PR TITLE
Add evaluation pipeline and metrics

### DIFF
--- a/configs/eval/baseline.yaml
+++ b/configs/eval/baseline.yaml
@@ -1,0 +1,28 @@
+checkpoint: "checkpoints/baseline/best.pt"
+tokenizer_file: "data/vocab/bpe.json"
+max_len: 256
+batch_size: 8
+num_workers: 2
+device: "cuda"
+output_json: "reports/baseline_eval.json"
+
+decoding:
+  max_new_tokens: 160
+
+# path split per task
+tasks:
+  text2rdf:
+    val: "data/processed/text2rdf.val.jsonl"
+    test: "data/processed/text2rdf.test.jsonl"
+  rdf2text:
+    val: "data/processed/rdf2text.val.jsonl"
+    test: "data/processed/rdf2text.test.jsonl"
+  rdfcomp1:
+    val: "data/processed/rdfcomp1.val.jsonl"
+    test: "data/processed/rdfcomp1.test.jsonl"
+  rdfcomp2:
+    val: "data/processed/rdfcomp2.val.jsonl"
+    test: "data/processed/rdfcomp2.test.jsonl"
+
+wandb:
+  mode: "disabled"

--- a/scripts/eval_all.py
+++ b/scripts/eval_all.py
@@ -1,0 +1,131 @@
+"""Script CLI per eseguire la valutazione completa."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+from src.eval.evaluate import evaluate_from_config
+from src.utils.config import add_common_overrides, apply_overrides, load_yaml
+
+
+def _maybe_init_wandb(cfg) -> Tuple[object, object]:
+    wandb_cfg = cfg.get("wandb") or {}
+    mode = str(wandb_cfg.get("mode", "disabled") or "disabled")
+    if mode.lower() == "disabled":
+        return None, None
+    try:
+        import wandb as _wandb
+    except ImportError as exc:  # pragma: no cover - dipende dall'ambiente
+        print(f"[wandb] libreria non disponibile ({exc}); logging disattivato.")
+        return None, None
+
+    init_kwargs = {
+        "project": wandb_cfg.get("project"),
+        "entity": wandb_cfg.get("entity"),
+        "name": wandb_cfg.get("run_name") or wandb_cfg.get("name"),
+        "tags": wandb_cfg.get("tags"),
+        "mode": mode,
+        "config": cfg,
+    }
+    init_kwargs = {k: v for k, v in init_kwargs.items() if v is not None}
+    if not init_kwargs.get("tags"):
+        init_kwargs.pop("tags", None)
+
+    try:
+        run = _wandb.init(**init_kwargs)
+        return run, _wandb
+    except Exception as exc:  # pragma: no cover - fallback raro
+        print(f"[wandb] init fallita ({exc}); logging disabilitato.")
+        return None, None
+
+
+def _flatten_for_logging(report: Dict[str, object]) -> Dict[str, float]:
+    flat: Dict[str, float] = {}
+    splits = report.get("splits", {})
+    for split_name, split_payload in splits.items():
+        if isinstance(split_payload, dict):
+            if "avg_loss" in split_payload:
+                flat[f"{split_name}/avg_loss"] = float(split_payload["avg_loss"])
+            tasks = split_payload.get("tasks", {})
+            for task_name, task_payload in tasks.items():
+                if not isinstance(task_payload, dict):
+                    continue
+                if "loss" in task_payload:
+                    flat[f"{split_name}/{task_name}/loss"] = float(task_payload["loss"])
+                metrics_by_task = task_payload.get("metrics", {})
+                for inner_task, metrics in metrics_by_task.items():
+                    if not isinstance(metrics, dict):
+                        continue
+                    base = f"{split_name}/{task_name}/{inner_task}"
+                    for key, value in metrics.items():
+                        if key == "samples":
+                            flat[f"{base}/samples"] = float(value)
+                        else:
+                            flat[f"{base}/{key}"] = float(value)
+    return flat
+
+
+def _print_report(report: Dict[str, object]):
+    print("=== Evaluation Report ===")
+    for split_name, split_payload in report.get("splits", {}).items():
+        print(f"\n[{split_name}]")
+        if not split_payload.get("tasks"):
+            print("  (nessun task)")
+            continue
+        if "avg_loss" in split_payload:
+            print(f"  avg_loss: {split_payload['avg_loss']:.4f}")
+        for task_name, task_payload in split_payload["tasks"].items():
+            loss = task_payload.get("loss")
+            samples = task_payload.get("num_samples", 0)
+            print(f"  - {task_name} (n={samples}) loss={loss:.4f}" if loss is not None else f"  - {task_name} (n={samples})")
+            metrics = task_payload.get("metrics", {})
+            for inner_task, vals in metrics.items():
+                numbers = [
+                    f"{k}={vals[k]:.2f}" for k in sorted(vals) if k != "samples"
+                ]
+                if numbers:
+                    print(f"      · {inner_task}: {', '.join(numbers)}")
+                print(f"        samples={vals.get('samples', 0)}")
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Valutazione multi-task")
+    add_common_overrides(ap)
+    ap.add_argument("--output", help="File JSON per salvare il report", default=None)
+    args = ap.parse_args()
+
+    cfg = load_yaml(args.cfg)
+    cfg = apply_overrides(cfg, args.override)
+
+    output_path = args.output or cfg.get("output_json")
+    if output_path is None:
+        output_path = Path(args.cfg).with_suffix(".report.json")
+    output_path = Path(output_path)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    wandb_run, wandb_module = _maybe_init_wandb(cfg)
+    try:
+        report = evaluate_from_config(cfg)
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(report, f, indent=2, ensure_ascii=False)
+        print(f"Report salvato in {output_path.resolve()}")
+        _print_report(report)
+
+        if wandb_run is not None:
+            flat_metrics = _flatten_for_logging(report)
+            try:
+                wandb_run.log(flat_metrics)
+            except Exception as exc:  # pragma: no cover - logging best effort
+                print(f"[wandb] log fallito: {exc}")
+    finally:
+        if wandb_run is not None and wandb_module is not None:
+            try:
+                wandb_module.finish()
+            except Exception as exc:  # pragma: no cover
+                print(f"[wandb] finish fallita: {exc}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/predict_example.py
+++ b/scripts/predict_example.py
@@ -1,0 +1,65 @@
+"""Esempio minimale di inference da riga di comando."""
+from __future__ import annotations
+
+import argparse
+
+from src.decoding.base import decode_to_text
+from src.eval.evaluate import load_model_and_tokenizer
+
+TASK_MARKERS = {
+    "text2rdf": "<Text2RDF>",
+    "rdf2text": "<RDF2Text>",
+    "rdfcomp2": "<CONTINUERDF>",
+    "rdfcomp1": "<MASK>",
+}
+
+
+def prepare_input(text: str, task: str | None) -> str:
+    text = text.strip()
+    if task:
+        marker = TASK_MARKERS.get(task)
+        if marker and marker not in text:
+            if task == "rdfcomp1" and "<MASK>" not in text:
+                text = f"{text} <MASK>".strip()
+            else:
+                text = f"{text} {marker}".strip()
+    return text
+
+
+def main():
+    ap = argparse.ArgumentParser(description="Esegue una singola predizione")
+    ap.add_argument("--checkpoint", required=True)
+    ap.add_argument("--tokenizer", required=True)
+    ap.add_argument("--input", required=True, help="Input testuale o RDF linearizzato")
+    ap.add_argument("--task", choices=list(TASK_MARKERS.keys()))
+    ap.add_argument("--device", default="cuda")
+    ap.add_argument("--max-new-tokens", type=int, default=128)
+    ap.add_argument("--model-override", nargs="*", default=[])
+    args = ap.parse_args()
+
+    overrides = {}
+    if args.model_override:
+        from src.utils.config import apply_overrides
+
+        overrides = apply_overrides({}, args.model_override)
+
+    model, tokenizer, device, _ = load_model_and_tokenizer(
+        args.tokenizer,
+        args.checkpoint,
+        device=args.device,
+        overrides=overrides,
+    )
+
+    prepared = prepare_input(args.input, args.task)
+    output = decode_to_text(
+        model,
+        tokenizer,
+        prepared,
+        max_new_tokens=args.max_new_tokens,
+        device=device,
+    )
+    print(output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/evaluate.py
+++ b/src/eval/evaluate.py
@@ -1,0 +1,251 @@
+"""Orchestratore di valutazione su split val/test."""
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from functools import partial
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+
+import torch
+from torch.utils.data import DataLoader
+
+from src.decoding.base import decode_to_text
+from src.eval.metrics import (
+    compute_accuracy,
+    compute_text_generation_metrics,
+    compute_triple_metrics,
+)
+from src.model.transformer import TinySeq2Seq
+from src.tokenizer.tokenizer_io import TokWrapper
+from src.training.dataloaders import JsonlSeq2Seq, pad_collate
+
+def _select_device(want: Optional[str]) -> str:
+    want = (want or "cuda").lower()
+    if want == "cuda" and torch.cuda.is_available():
+        return "cuda"
+    return "cpu"
+
+
+def _normalise_text(text: str) -> str:
+    if not text:
+        return ""
+    cleaned = [tok for tok in text.replace("\n", " ").split() if tok and tok != "<pad>"]
+    return " ".join(cleaned).strip()
+
+
+def _load_model_from_checkpoint(
+    checkpoint_path: str,
+    tokenizer: TokWrapper,
+    device: str,
+    overrides: Optional[Mapping[str, object]] = None,
+) -> tuple[TinySeq2Seq, Dict[str, object]]:
+    overrides = dict(overrides or {})
+    ckpt = torch.load(checkpoint_path, map_location=device)
+    saved_cfg: MutableMapping[str, object] = dict(ckpt.get("config", {}))
+    saved_cfg.update(overrides)
+
+    required = ["d_model", "nhead", "enc_layers", "dec_layers", "ff_dim", "dropout"]
+    missing = [k for k in required if k not in saved_cfg]
+    if missing:
+        raise ValueError(
+            f"Checkpoint privo dei parametri modello {missing}. Fornisci override espliciti."
+        )
+
+    model = TinySeq2Seq(
+        vocab_size=tokenizer.vocab_size(),
+        d_model=int(saved_cfg["d_model"]),
+        nhead=int(saved_cfg["nhead"]),
+        num_encoder_layers=int(saved_cfg["enc_layers"]),
+        num_decoder_layers=int(saved_cfg["dec_layers"]),
+        dim_feedforward=int(saved_cfg["ff_dim"]),
+        dropout=float(saved_cfg["dropout"]),
+        pad_id=tokenizer.pad_id,
+        tie_embeddings=True,
+    ).to(device)
+    model.load_state_dict(ckpt["model"])
+    model.eval()
+    return model, dict(saved_cfg)
+
+
+def load_model_and_tokenizer(
+    tokenizer_file: str,
+    checkpoint_path: str,
+    *,
+    device: Optional[str] = None,
+    overrides: Optional[Mapping[str, object]] = None,
+) -> tuple[TinySeq2Seq, TokWrapper, str, Dict[str, object]]:
+    device_sel = _select_device(device)
+    tokenizer = TokWrapper(tokenizer_file)
+    model, saved_cfg = _load_model_from_checkpoint(
+        checkpoint_path, tokenizer, device_sel, overrides
+    )
+    return model, tokenizer, device_sel, saved_cfg
+
+
+@torch.no_grad()
+def _compute_loss(model: TinySeq2Seq, dataloader: DataLoader, device: str) -> float:
+    total = 0.0
+    steps = 0
+    for batch in dataloader:
+        inp = batch["input_ids"].to(device, non_blocking=True)
+        att = batch["attention_mask"].to(device, non_blocking=True)
+        lab = batch["labels"].to(device, non_blocking=True)
+        out = model(inp, att, labels=lab)
+        loss = out.get("loss")
+        if loss is None:
+            continue
+        total += float(loss.item())
+        steps += 1
+    if steps == 0:
+        return 0.0
+    return total / steps
+
+
+@torch.no_grad()
+def _generate_predictions(
+    model: TinySeq2Seq,
+    tokenizer: TokWrapper,
+    dataset: JsonlSeq2Seq,
+    device: str,
+    max_new_tokens: int,
+) -> tuple[List[str], List[str], List[str]]:
+    predictions: List[str] = []
+    references: List[str] = []
+    tasks: List[str] = []
+
+    for ex in dataset.items:
+        pred = decode_to_text(
+            model,
+            tokenizer,
+            ex.input,
+            max_new_tokens=max_new_tokens,
+            device=device,
+        )
+        predictions.append(_normalise_text(pred))
+        references.append(_normalise_text(ex.target))
+        tasks.append(ex.task or "unknown")
+    return predictions, references, tasks
+
+
+def _group_by_task(
+    predictions: Iterable[str],
+    references: Iterable[str],
+    tasks: Iterable[str],
+) -> Dict[str, Dict[str, List[str]]]:
+    buckets: Dict[str, Dict[str, List[str]]] = defaultdict(lambda: {"pred": [], "ref": []})
+    for pred, ref, task in zip(predictions, references, tasks):
+        buckets[task]["pred"].append(pred)
+        buckets[task]["ref"].append(ref)
+    return buckets
+
+
+def _metrics_for_task(task: str, preds: List[str], refs: List[str]) -> Dict[str, float]:
+    if task == "rdf2text":
+        return compute_text_generation_metrics(preds, refs)
+    if task in {"text2rdf", "rdfcomp2"}:
+        return compute_triple_metrics(preds, refs)
+    if task == "rdfcomp1":
+        return compute_accuracy(preds, refs)
+    # fallback: treat as generation
+    return compute_text_generation_metrics(preds, refs)
+
+
+def _normalise_tasks_config(raw_tasks) -> Dict[str, Dict[str, str]]:
+    if isinstance(raw_tasks, Mapping):
+        return {str(name): dict(cfg) for name, cfg in raw_tasks.items()}
+    tasks_dict: Dict[str, Dict[str, str]] = {}
+    for entry in raw_tasks or []:
+        if isinstance(entry, Mapping):
+            name = entry.get("name") or entry.get("task")
+            if not name:
+                raise ValueError("Ogni task deve avere un campo 'name' o 'task'.")
+            tasks_dict[str(name)] = dict(entry)
+        else:
+            raise ValueError("Formato task non valido. Usa dict o lista di dict.")
+    return tasks_dict
+
+
+def evaluate_from_config(config: Mapping[str, object]) -> Dict[str, object]:
+    if "checkpoint" not in config:
+        raise ValueError("Il config di valutazione richiede 'checkpoint'.")
+    if "tokenizer_file" not in config:
+        raise ValueError("Il config di valutazione richiede 'tokenizer_file'.")
+    if "tasks" not in config and "datasets" not in config:
+        raise ValueError("Specifica la sezione 'tasks' con i path val/test per task.")
+
+    model_overrides = config.get("model") or {}
+    model, tokenizer, device, saved_cfg = load_model_and_tokenizer(
+        str(config["tokenizer_file"]),
+        str(config["checkpoint"]),
+        device=str(config.get("device", "cuda")),
+        overrides=model_overrides,
+    )
+
+    max_len = int(config.get("max_len", saved_cfg.get("max_len", 256)))
+    decode_cfg = config.get("decoding") or {}
+    max_new_tokens = int(decode_cfg.get("max_new_tokens", max_len))
+
+    batch_size = int(config.get("batch_size", 8))
+    num_workers = int(config.get("num_workers", 0))
+    pin_memory = device == "cuda"
+
+    tasks_cfg = _normalise_tasks_config(
+        config.get("tasks") if config.get("tasks") is not None else config.get("datasets")
+    )
+
+    collate = partial(pad_collate, pad_id=tokenizer.pad_id)
+
+    report: Dict[str, object] = {
+        "checkpoint": os.path.abspath(str(config["checkpoint"])),
+        "device": device,
+        "splits": {},
+    }
+
+    for split in ("val", "test"):
+        split_payload: Dict[str, object] = {"tasks": {}}
+        weighted_loss = 0.0
+        total_samples = 0
+        for task_name, cfg_task in tasks_cfg.items():
+            path = cfg_task.get(split)
+            if not path:
+                continue
+            dataset = JsonlSeq2Seq(str(path), tokenizer=tokenizer, max_len=max_len)
+            dataloader = DataLoader(
+                dataset,
+                batch_size=batch_size,
+                shuffle=False,
+                collate_fn=collate,
+                num_workers=num_workers,
+                pin_memory=pin_memory,
+            )
+            loss = _compute_loss(model, dataloader, device)
+            preds, refs, task_tags = _generate_predictions(
+                model, tokenizer, dataset, device, max_new_tokens
+            )
+            grouped = _group_by_task(preds, refs, task_tags)
+            metrics_payload: Dict[str, object] = {}
+            for t_name, bucket in grouped.items():
+                metrics = _metrics_for_task(t_name, bucket["pred"], bucket["ref"])
+                metrics_payload[t_name] = {
+                    **{k: float(v) for k, v in metrics.items()},
+                    "samples": len(bucket["pred"]),
+                }
+
+            if not metrics_payload:
+                metrics_payload[task_name] = {"samples": len(dataset)}
+
+            split_payload["tasks"][task_name] = {
+                "path": str(path),
+                "loss": float(loss),
+                "num_samples": len(dataset),
+                "metrics": metrics_payload,
+            }
+            weighted_loss += loss * len(dataset)
+            total_samples += len(dataset)
+
+        if total_samples > 0:
+            split_payload["avg_loss"] = float(weighted_loss / total_samples)
+            split_payload["num_samples"] = total_samples
+        report["splits"][split] = split_payload
+
+    return report

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -1,0 +1,282 @@
+"""Utility per il calcolo delle metriche di valutazione."""
+from __future__ import annotations
+
+import math
+from collections import Counter
+from typing import Iterable, List, Sequence, Tuple
+
+from src.data.serialization import parse_rdf
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tokenize(text: str) -> List[str]:
+    if text is None:
+        return []
+    return [tok for tok in text.strip().split() if tok]
+
+
+def _ngram_counts(tokens: Sequence[str], n: int) -> Counter:
+    if n <= 0:
+        return Counter()
+    return Counter(tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1))
+
+
+# ---------------------------------------------------------------------------
+# Testo ↔ testo: BLEU / ROUGE-L / METEOR
+# ---------------------------------------------------------------------------
+
+
+def corpus_bleu(
+    predictions: Sequence[str],
+    references: Sequence[Sequence[str] | str],
+    max_order: int = 4,
+    smooth: float = 1e-9,
+) -> float:
+    """Calcola il BLEU corpus-level (0–100)."""
+
+    if len(predictions) != len(references):
+        raise ValueError("predictions e references devono avere la stessa lunghezza")
+    matches_by_order = [0] * max_order
+    possible_matches_by_order = [0] * max_order
+    ref_length = 0
+    pred_length = 0
+
+    for pred, ref in zip(predictions, references):
+        pred_tokens = _tokenize(pred)
+        ref_list = [ref] if isinstance(ref, str) else list(ref)
+        ref_tokens_list = [_tokenize(r) for r in ref_list]
+        pred_length += len(pred_tokens)
+
+        if ref_tokens_list:
+            ref_lengths = [len(rt) for rt in ref_tokens_list]
+            closest_ref_len = min(
+                ref_lengths,
+                key=lambda rl: (abs(rl - len(pred_tokens)), rl),
+            )
+            ref_length += closest_ref_len
+        else:
+            ref_length += 0
+
+        for n in range(1, max_order + 1):
+            pred_ngrams = _ngram_counts(pred_tokens, n)
+            max_ref_counts: Counter = Counter()
+            for ref_tokens in ref_tokens_list:
+                ref_ngrams = _ngram_counts(ref_tokens, n)
+                for ngram, count in ref_ngrams.items():
+                    if count > max_ref_counts[ngram]:
+                        max_ref_counts[ngram] = count
+            overlap = {
+                ngram: min(count, max_ref_counts.get(ngram, 0))
+                for ngram, count in pred_ngrams.items()
+            }
+            matches_by_order[n - 1] += sum(overlap.values())
+            possible_matches_by_order[n - 1] += max(0, len(pred_tokens) - n + 1)
+
+    if pred_length == 0:
+        return 0.0
+
+    precisions: List[float] = []
+    for i in range(max_order):
+        if possible_matches_by_order[i] == 0:
+            precisions.append(0.0)
+        else:
+            precisions.append(
+                (matches_by_order[i] + smooth) / (possible_matches_by_order[i] + smooth)
+            )
+
+    if min(precisions) <= 0:
+        geo_mean = 0.0
+    else:
+        geo_mean = math.exp(sum(math.log(p) for p in precisions) / max_order)
+
+    if pred_length < ref_length and pred_length > 0:
+        bp = math.exp(1 - ref_length / pred_length)
+    else:
+        bp = 1.0
+
+    bleu = geo_mean * bp
+    return float(bleu * 100)
+
+
+def rouge_l_score(predictions: Sequence[str], references: Sequence[str]) -> float:
+    """ROUGE-L medio (F1 con beta=1.2) restituito in percentuale."""
+
+    if len(predictions) != len(references):
+        raise ValueError("predictions e references devono avere la stessa lunghezza")
+
+    def lcs(a: Sequence[str], b: Sequence[str]) -> int:
+        m, n = len(a), len(b)
+        if m == 0 or n == 0:
+            return 0
+        dp = [[0] * (n + 1) for _ in range(m + 1)]
+        for i in range(m):
+            for j in range(n):
+                if a[i] == b[j]:
+                    dp[i + 1][j + 1] = dp[i][j] + 1
+                else:
+                    dp[i + 1][j + 1] = max(dp[i][j + 1], dp[i + 1][j])
+        return dp[m][n]
+
+    scores: List[float] = []
+    beta = 1.2
+    beta_sq = beta ** 2
+
+    for pred, ref in zip(predictions, references):
+        pred_tokens = _tokenize(pred)
+        ref_tokens = _tokenize(ref)
+        if not pred_tokens or not ref_tokens:
+            scores.append(0.0)
+            continue
+        lcs_len = lcs(pred_tokens, ref_tokens)
+        prec = lcs_len / len(pred_tokens)
+        rec = lcs_len / len(ref_tokens)
+        if prec == 0 or rec == 0:
+            scores.append(0.0)
+        else:
+            f_score = ((1 + beta_sq) * prec * rec) / (rec + beta_sq * prec)
+            scores.append(f_score)
+    if not scores:
+        return 0.0
+    return float(sum(scores) / len(scores) * 100)
+
+
+def meteor_score(predictions: Sequence[str], references: Sequence[str]) -> float:
+    """Implementazione semplificata di METEOR (precisione/recall unigrammi)."""
+
+    if len(predictions) != len(references):
+        raise ValueError("predictions e references devono avere la stessa lunghezza")
+
+    alpha = 0.9
+    beta = 3.0
+    gamma = 0.5
+
+    scores: List[float] = []
+    for pred, ref in zip(predictions, references):
+        hyp = _tokenize(pred.lower())
+        ref_tokens = _tokenize(ref.lower())
+        if not hyp or not ref_tokens:
+            scores.append(0.0)
+            continue
+
+        matched_ref_idx: List[int] = []
+        matched_mask = [False] * len(ref_tokens)
+        matches = 0
+        for tok in hyp:
+            found = False
+            for idx, ref_tok in enumerate(ref_tokens):
+                if not matched_mask[idx] and ref_tok == tok:
+                    matched_mask[idx] = True
+                    matched_ref_idx.append(idx)
+                    matches += 1
+                    found = True
+                    break
+            if not found:
+                continue
+
+        if matches == 0:
+            scores.append(0.0)
+            continue
+
+        matched_ref_idx.sort()
+        chunks = 1
+        for i in range(1, len(matched_ref_idx)):
+            if matched_ref_idx[i] != matched_ref_idx[i - 1] + 1:
+                chunks += 1
+
+        precision = matches / len(hyp)
+        recall = matches / len(ref_tokens)
+        f_mean = (precision * recall) / (
+            (alpha * precision) + ((1 - alpha) * recall)
+        )
+        frag = chunks / matches
+        penalty = gamma * (frag ** beta)
+        score = (1 - penalty) * f_mean
+        scores.append(score)
+
+    if not scores:
+        return 0.0
+    return float(sum(scores) / len(scores) * 100)
+
+
+# ---------------------------------------------------------------------------
+# Triple RDF e accuracy
+# ---------------------------------------------------------------------------
+
+
+def _coerce_triples(obj: Iterable | str) -> List[Tuple[str, str, str]]:
+    if isinstance(obj, str):
+        return parse_rdf(obj)
+    triples: List[Tuple[str, str, str]] = []
+    for item in obj or []:
+        if isinstance(item, (list, tuple)) and len(item) == 3:
+            triples.append(tuple(map(str, item)))
+    return triples
+
+
+def triple_precision_recall_f1(
+    predictions: Sequence[Iterable | str], references: Sequence[Iterable | str]
+) -> dict:
+    if len(predictions) != len(references):
+        raise ValueError("predictions e references devono avere la stessa lunghezza")
+
+    tp = fp = fn = 0
+    for pred, ref in zip(predictions, references):
+        pred_set = set(_coerce_triples(pred))
+        ref_set = set(_coerce_triples(ref))
+        inter = pred_set & ref_set
+        tp += len(inter)
+        fp += len(pred_set - inter)
+        fn += len(ref_set - inter)
+
+    precision = tp / (tp + fp) if (tp + fp) > 0 else 0.0
+    recall = tp / (tp + fn) if (tp + fn) > 0 else 0.0
+    if precision + recall == 0:
+        f1 = 0.0
+    else:
+        f1 = 2 * precision * recall / (precision + recall)
+    return {
+        "precision": precision * 100,
+        "recall": recall * 100,
+        "f1": f1 * 100,
+    }
+
+
+def accuracy_score(predictions: Sequence[str], references: Sequence[str]) -> float:
+    if len(predictions) != len(references):
+        raise ValueError("predictions e references devono avere la stessa lunghezza")
+    total = len(predictions)
+    if total == 0:
+        return 0.0
+    correct = 0
+    for pred, ref in zip(predictions, references):
+        if (pred or "").strip() == (ref or "").strip():
+            correct += 1
+    return float(correct / total * 100)
+
+
+# ---------------------------------------------------------------------------
+# Interfacce comode per blocchi di valutazione
+# ---------------------------------------------------------------------------
+
+
+def compute_text_generation_metrics(
+    predictions: Sequence[str], references: Sequence[str]
+) -> dict:
+    return {
+        "bleu": corpus_bleu(predictions, references),
+        "rouge_l": rouge_l_score(predictions, references),
+        "meteor": meteor_score(predictions, references),
+    }
+
+
+def compute_triple_metrics(
+    predictions: Sequence[Iterable | str], references: Sequence[Iterable | str]
+) -> dict:
+    return triple_precision_recall_f1(predictions, references)
+
+
+def compute_accuracy(predictions: Sequence[str], references: Sequence[str]) -> dict:
+    return {"accuracy": accuracy_score(predictions, references)}

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,71 @@
+import pytest
+
+from src.eval.metrics import (
+    accuracy_score,
+    compute_accuracy,
+    compute_text_generation_metrics,
+    compute_triple_metrics,
+    corpus_bleu,
+    meteor_score,
+    rouge_l_score,
+    triple_precision_recall_f1,
+)
+
+
+def test_bleu_perfect_match():
+    pred = ["the cat is on the mat"]
+    ref = ["the cat is on the mat"]
+    assert corpus_bleu(pred, ref) == pytest.approx(100.0)
+
+
+def test_bleu_partial_match():
+    pred = ["the cat sat on the mat"]
+    ref = ["the cat is on the mat"]
+    score = corpus_bleu(pred, ref)
+    assert 0.0 < score < 100.0
+
+
+def test_rouge_l_score():
+    pred = ["the cat sat on the mat"]
+    ref = ["the cat is on the mat"]
+    score = rouge_l_score(pred, ref)
+    assert 0.0 < score < 100.0
+
+
+def test_meteor_score():
+    pred = ["The quick brown fox"]
+    ref = ["the quick fox"]
+    score = meteor_score(pred, ref)
+    assert 0.0 < score <= 100.0
+
+
+def test_triple_f1_from_strings():
+    pred = ["<SOT> <SUBJ> a <PRED> b <OBJ> c <EOT> <SOT> <SUBJ> a <PRED> d <OBJ> e <EOT>"]
+    ref = ["<SOT> <SUBJ> a <PRED> b <OBJ> c <EOT>"]
+    metrics = triple_precision_recall_f1(pred, ref)
+    assert pytest.approx(metrics["precision"], rel=1e-6) == 50.0
+    assert pytest.approx(metrics["recall"], rel=1e-6) == 100.0
+    assert metrics["f1"] > 0.0
+
+
+def test_accuracy_score():
+    preds = ["entity", "wrong"]
+    refs = ["entity", "gold"]
+    score = accuracy_score(preds, refs)
+    assert score == pytest.approx(50.0)
+
+
+def test_compute_helpers_return_expected_keys():
+    preds = ["the cat is on the mat"]
+    refs = ["the cat is on the mat"]
+    text_metrics = compute_text_generation_metrics(preds, refs)
+    assert set(text_metrics.keys()) == {"bleu", "rouge_l", "meteor"}
+
+    triple_metrics = compute_triple_metrics(
+        ["<SOT> <SUBJ> x <PRED> y <OBJ> z <EOT>"],
+        ["<SOT> <SUBJ> x <PRED> y <OBJ> z <EOT>"],
+    )
+    assert triple_metrics["f1"] == pytest.approx(100.0)
+
+    acc_metrics = compute_accuracy(["foo"], ["foo"])
+    assert acc_metrics == {"accuracy": pytest.approx(100.0)}


### PR DESCRIPTION
## Summary
- implement BLEU, ROUGE-L, METEOR, triple F1 and accuracy utilities with unit coverage
- add evaluation orchestrator, configuration, CLI subcommands and reporting script for val/test runs
- document evaluation workflow, provide baseline eval config and prediction helper script

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0e45daca08331ac1b5841a2d06ef7