### PR TITLE
Add W&B evaluation helper and CLI support

### DIFF
--- a/scripts/eval_all.py
+++ b/scripts/eval_all.py
@@ -1,0 +1,50 @@
+"""Entry point da riga di comando per la valutazione batch.
+
+Lo script carica la configurazione YAML, esegue ``evaluate_from_config`` e si
+occupa di inizializzare/chiudere correttamente la run W&B. La logica è
+condivisa con ``src.cli`` tramite ``src.utils.wandb_logging``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+
+from src.eval.evaluate import evaluate_from_config
+from src.utils.config import load_yaml
+from src.utils.wandb_logging import _flatten_for_logging, _maybe_init_wandb
+
+
+def _log_metrics(wandb_run, result):
+    if wandb_run is None:
+        return
+    payload = {
+        "summary": result.get("summary", {}),
+        "metrics": result.get("metrics", {}),
+    }
+    flat = _flatten_for_logging(payload)
+    if flat:
+        wandb_run.log(flat)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Valuta tutti i task dal config")
+    parser.add_argument("--config", "--cfg", dest="cfg", required=True, help="File YAML")
+    args = parser.parse_args()
+
+    cfg = load_yaml(args.cfg)
+
+    wandb_run, _wandb_module = _maybe_init_wandb(cfg.get("wandb"), run_config=cfg)
+    try:
+        result = evaluate_from_config(cfg)
+        _log_metrics(wandb_run, result)
+        output_path = cfg.get("output_json")
+        if output_path:
+            print(f"[eval] metrics saved to {output_path}")
+        print(json.dumps(result, indent=2, sort_keys=True))
+    finally:
+        if wandb_run is not None:
+            wandb_run.finish()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/eval/evaluate.py
+++ b/src/eval/evaluate.py
@@ -1,0 +1,140 @@
+"""Routine di valutazione per NanoSocrates.
+
+Il modulo fornisce ``evaluate_from_config`` che legge una configurazione YAML
+(e.g. usata da CLI e script) e restituisce un dizionario con le metriche per
+ciascun task insieme a statistiche aggregate. La funzione supporta dataset
+semplici dove le predizioni e i target sono salvati in JSONL con chiavi
+``prediction`` e ``target`` (personalizzabili tramite config).
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+@dataclass
+class TaskConfig:
+    """Configurazione di un singolo task di valutazione."""
+
+    name: str
+    predictions: Path
+    references: Path
+    prediction_field: str = "prediction"
+    reference_field: str = "target"
+    metric: str = "accuracy"
+
+    @classmethod
+    def from_mapping(cls, data: Mapping[str, Any]) -> "TaskConfig":
+        missing = [k for k in ("name", "predictions", "references") if k not in data]
+        if missing:
+            raise ValueError(f"Missing keys for evaluation task: {', '.join(missing)}")
+        return cls(
+            name=str(data["name"]),
+            predictions=Path(data["predictions"]),
+            references=Path(data["references"]),
+            prediction_field=str(data.get("prediction_field", "prediction")),
+            reference_field=str(data.get("reference_field", "target")),
+            metric=str(data.get("metric", "accuracy")),
+        )
+
+
+def _load_jsonl(path: Path) -> list[Mapping[str, Any]]:
+    if not path.exists():
+        raise FileNotFoundError(f"Input file not found: {path}")
+    records: list[Mapping[str, Any]] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            records.append(json.loads(line))
+    return records
+
+
+def _compute_accuracy(
+    predictions: Iterable[Any],
+    references: Iterable[Any],
+) -> tuple[int, int, float]:
+    total = 0
+    correct = 0
+    for pred, ref in zip(predictions, references):
+        total += 1
+        if pred == ref:
+            correct += 1
+    accuracy = (correct / total) if total else 0.0
+    return correct, total, accuracy
+
+
+SUPPORTED_METRICS = {
+    "accuracy": _compute_accuracy,
+    "exact_match": _compute_accuracy,
+}
+
+
+def evaluate_from_config(cfg: Mapping[str, Any]) -> Mapping[str, Any]:
+    """Esegue la valutazione dei task descritti nel config e ritorna le metriche."""
+
+    tasks_cfg = cfg.get("tasks") or []
+    tasks = [TaskConfig.from_mapping(task_cfg) for task_cfg in tasks_cfg]
+    if not tasks:
+        raise ValueError("Evaluation config must define at least one task")
+
+    output_path = cfg.get("output_json")
+    if output_path:
+        output_path = Path(output_path)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    metrics_by_task: dict[str, dict[str, Any]] = {}
+    total_examples = 0
+    total_correct = 0
+
+    for task in tasks:
+        records_pred = _load_jsonl(task.predictions)
+        records_ref = _load_jsonl(task.references)
+        if len(records_pred) != len(records_ref):
+            raise ValueError(
+                f"Mismatched number of records for task '{task.name}':"
+                f" {len(records_pred)} predictions vs {len(records_ref)} references"
+            )
+        metric_fn = SUPPORTED_METRICS.get(task.metric.lower())
+        if metric_fn is None:
+            raise ValueError(
+                f"Unsupported metric '{task.metric}' for task '{task.name}'"
+            )
+        preds = [record.get(task.prediction_field) for record in records_pred]
+        refs = [record.get(task.reference_field) for record in records_ref]
+        correct, total, accuracy = metric_fn(preds, refs)
+        metrics_by_task[task.name] = {
+            "accuracy": accuracy,
+            "correct": correct,
+            "total": total,
+        }
+        total_examples += total
+        total_correct += correct
+
+    summary = {
+        "tasks": len(tasks),
+        "total_examples": total_examples,
+        "micro_accuracy": (total_correct / total_examples) if total_examples else 0.0,
+        "macro_accuracy": (
+            sum(task_metrics["accuracy"] for task_metrics in metrics_by_task.values())
+            / len(metrics_by_task)
+            if metrics_by_task
+            else 0.0
+        ),
+    }
+
+    result = {
+        "metrics": metrics_by_task,
+        "summary": summary,
+    }
+
+    if output_path:
+        output_path.write_text(json.dumps(result, indent=2, sort_keys=True))
+
+    return result
+
+
+__all__ = ["evaluate_from_config"]

--- a/src/utils/wandb_logging.py
+++ b/src/utils/wandb_logging.py
@@ -1,0 +1,126 @@
+"""Utility condivise per l'inizializzazione e il logging su Weights & Biases.
+
+Questo modulo definisce le stesse primitive che venivano utilizzate dallo
+script ``scripts/eval_all.py`` così da poterle riutilizzare anche dalla CLI.
+"""
+from __future__ import annotations
+
+from typing import Any, Iterable, Mapping, MutableMapping, Tuple
+
+
+def _build_wandb_init_kwargs(
+    wandb_cfg: Mapping[str, Any],
+    run_config: Mapping[str, Any] | None,
+    mode_value: str,
+) -> MutableMapping[str, Any]:
+    """Prepara gli argomenti da passare a ``wandb.init``.
+
+    L'helper rimuove le chiavi impostate a ``None`` per evitare warning e
+    supporta ``tags`` facoltativi. ``run_config`` viene allegato così da avere
+    il config completo visibile nella run.
+    """
+
+    init_kwargs: MutableMapping[str, Any] = {
+        "project": wandb_cfg.get("project"),
+        "entity": wandb_cfg.get("entity"),
+        "name": wandb_cfg.get("run_name"),
+        "tags": wandb_cfg.get("tags"),
+        "mode": mode_value,
+    }
+    if run_config is not None:
+        init_kwargs["config"] = run_config
+
+    # ``tags`` può essere ``None`` o una lista vuota: in entrambi i casi la
+    # rimuoviamo per evitare che wandb alzi errori.
+    if not init_kwargs.get("tags"):
+        init_kwargs.pop("tags", None)
+
+    # Filtra i valori ``None``.
+    return {k: v for k, v in init_kwargs.items() if v is not None}
+
+
+def _maybe_init_wandb(
+    wandb_cfg: Mapping[str, Any] | None,
+    run_config: Mapping[str, Any] | None = None,
+) -> Tuple[Any, Any]:
+    """Prova ad inizializzare una run Weights & Biases.
+
+    Restituisce ``(run, module)`` se la run è stata creata con successo oppure
+    ``(None, None)`` se il logging è disabilitato o non è disponibile la
+    libreria. In caso di errori prova automaticamente un fallback in modalità
+    ``offline`` mantenendo lo stesso payload di configurazione.
+    """
+
+    wandb_cfg = wandb_cfg or {}
+    mode = str(wandb_cfg.get("mode", "disabled") or "disabled")
+    if mode.lower() == "disabled":
+        return None, None
+
+    try:
+        import wandb as wandb_module  # type: ignore
+    except Exception as exc:  # pragma: no cover - messaggi diagnostici
+        print(f"[wandb] library not available ({exc}); skipping logging.")
+        return None, None
+
+    init_kwargs = _build_wandb_init_kwargs(wandb_cfg, run_config, mode)
+
+    try:
+        run = wandb_module.init(**init_kwargs)
+    except Exception as exc:  # pragma: no cover - dipende da wandb
+        print(f"[wandb] init failed ({exc}); retrying in offline mode.")
+        try:
+            init_kwargs_offline = _build_wandb_init_kwargs(
+                wandb_cfg, run_config, "offline"
+            )
+            run = wandb_module.init(**init_kwargs_offline)
+        except Exception as offline_exc:  # pragma: no cover
+            print(
+                f"[wandb] offline fallback failed ({offline_exc}); disabling logging."
+            )
+            return None, None
+    try:
+        if run_config is not None:
+            run.config.update(run_config, allow_val_change=True)
+    except Exception as exc:  # pragma: no cover - solo logging
+        print(f"[wandb] config update failed: {exc}")
+    return run, wandb_module
+
+
+def _flatten_for_logging(
+    payload: Mapping[str, Any] | Iterable[Tuple[str, Any]],
+    *,
+    prefix: str | None = None,
+    sep: str = "/",
+) -> dict[str, float]:
+    """Appiattisce dizionari arbitrariamente annidati per il logging W&B.
+
+    Solo i valori numerici (int/float/bool) vengono mantenuti: gli altri tipi
+    vengono scartati. Le liste/tuple vengono espanse numerando gli elementi.
+    """
+
+    flat: dict[str, float] = {}
+
+    if isinstance(payload, Mapping):
+        items = payload.items()
+    else:
+        items = payload
+
+    for key, value in items:
+        full_key = f"{prefix}{sep}{key}" if prefix else str(key)
+        if isinstance(value, Mapping):
+            flat.update(_flatten_for_logging(value, prefix=full_key, sep=sep))
+        elif isinstance(value, (list, tuple)):
+            for idx, sub_value in enumerate(value):
+                sub_key = f"{full_key}{sep}{idx}"
+                if isinstance(sub_value, Mapping):
+                    flat.update(
+                        _flatten_for_logging(sub_value, prefix=sub_key, sep=sep)
+                    )
+                elif isinstance(sub_value, (int, float)):
+                    flat[sub_key] = float(sub_value)
+        elif isinstance(value, (int, float, bool)):
+            flat[full_key] = float(value)
+    return flat
+
+
+__all__ = ["_maybe_init_wandb", "_flatten_for_logging"]

--- a/tests/test_cli_evaluate.py
+++ b/tests/test_cli_evaluate.py
@@ -1,0 +1,98 @@
+import json
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from src.cli import cmd_evaluate
+
+
+class DummyConfig:
+    def __init__(self):
+        self.data = {}
+
+    def update(self, payload, allow_val_change=False):  # noqa: ARG002 - compat
+        self.data.update(payload)
+
+
+class DummyRun:
+    def __init__(self):
+        self.logged = []
+        self.finished = False
+        self.config = DummyConfig()
+
+    def log(self, payload, step=None):  # noqa: D401 - compat con wandb
+        self.logged.append((payload, step))
+
+    def finish(self):
+        self.finished = True
+
+
+class DummyWandbModule:
+    def __init__(self):
+        self.init_kwargs = []
+        self.runs = []
+
+    def init(self, **kwargs):
+        run = DummyRun()
+        self.init_kwargs.append(kwargs)
+        self.runs.append(run)
+        return run
+
+
+def _write_jsonl(path: Path, rows):
+    with path.open("w", encoding="utf-8") as f:
+        for row in rows:
+            f.write(json.dumps(row) + "\n")
+
+
+def test_cmd_evaluate_logs_to_wandb(monkeypatch, tmp_path):
+    predictions = tmp_path / "preds.jsonl"
+    references = tmp_path / "refs.jsonl"
+    metrics_path = tmp_path / "metrics.json"
+
+    _write_jsonl(predictions, [{"prediction": "a"}, {"prediction": "b"}])
+    _write_jsonl(references, [{"target": "a"}, {"target": "c"}])
+
+    cfg = {
+        "tasks": [
+            {
+                "name": "task_a",
+                "predictions": str(predictions),
+                "references": str(references),
+            }
+        ],
+        "output_json": str(metrics_path),
+        "wandb": {
+            "project": "proj",
+            "entity": "ent",
+            "run_name": "test-run",
+            "mode": "online",
+        },
+    }
+
+    cfg_path = tmp_path / "eval.yaml"
+    cfg_path.write_text(yaml.safe_dump(cfg), encoding="utf-8")
+
+    dummy_wandb = DummyWandbModule()
+    monkeypatch.setitem(sys.modules, "wandb", dummy_wandb)
+
+    args = type("Args", (), {"cfg": str(cfg_path), "override": []})()
+    cmd_evaluate(args)
+
+    assert dummy_wandb.init_kwargs
+    assert metrics_path.exists()
+
+    run = dummy_wandb.runs[0]
+    assert run.finished is True
+    assert run.logged, "expected wandb.log to be called"
+
+    payload = run.logged[0][0]
+    assert "metrics/task_a/accuracy" in payload
+
+    result_payload = json.loads(metrics_path.read_text(encoding="utf-8"))
+    assert result_payload["metrics"]["task_a"]["accuracy"] == 0.5


### PR DESCRIPTION
## Summary
- extract the W&B initialization/logging helpers used by the evaluation script into a reusable module
- hook up the evaluation CLI to reuse the helpers, run `evaluate_from_config`, log flattened metrics, and close the run just like the script
- add an evaluation routine plus a CLI test that exercises the WandB integration and checks that metrics are persisted to disk

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0e7d5459c833184e063fd56337e10