### PR TITLE
Add span-aware RDF completion training support

### DIFF
--- a/configs/eval/baseline.yaml
+++ b/configs/eval/baseline.yaml
@@ -9,6 +9,9 @@ output_json: "reports/baseline_eval.json"
 decoding:
   max_new_tokens: 160
 
+# abilita la valutazione delle maschere quando il checkpoint le supporta
+enable_entity_spans: true
+
 # path split per task
 tasks:
   text2rdf:

--- a/configs/train/baseline.yaml
+++ b/configs/train/baseline.yaml
@@ -14,6 +14,10 @@ ff_dim: 1536
 dropout: 0.1
 max_len: 256
 
+# span masking (disabilitato)
+enable_entity_spans: false
+compute_span_metrics: false
+
 # training
 batch_size: 16
 num_epochs: 10

--- a/configs/train/mix_3322.yaml
+++ b/configs/train/mix_3322.yaml
@@ -31,6 +31,10 @@ ff_dim: 1536
 dropout: 0.1
 max_len: 512
 
+# span masking per RDF Completion 1
+enable_entity_spans: true
+compute_span_metrics: true
+
 # training
 batch_size: 16
 num_epochs: 10

--- a/configs/train/rope_on.yaml
+++ b/configs/train/rope_on.yaml
@@ -15,6 +15,10 @@ ff_dim: 1536
 dropout: 0.1
 max_len: 256
 
+# span masking (disabilitato per esperimento RoPE)
+enable_entity_spans: false
+compute_span_metrics: false
+
 # training
 batch_size: 16
 num_epochs: 10

--- a/src/model/losses.py
+++ b/src/model/losses.py
@@ -1,0 +1,108 @@
+"""Utility functions for computing seq2seq losses and auxiliary metrics."""
+
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import torch
+import torch.nn.functional as F
+
+
+def _align_logits_and_labels(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+) -> tuple[torch.Tensor, torch.Tensor]:
+    """Return tensors aligned for loss computation.
+
+    The decoder may produce logits that are one step shorter than the labels
+    (teacher forcing with implicit <SOT>). This helper mirrors the logic used in
+    :class:`TinySeq2Seq` to keep the behaviour consistent in one place.
+    """
+
+    if labels.size(1) == logits.size(1):
+        return logits, labels
+    if labels.size(1) == logits.size(1) + 1:
+        return logits, labels[:, 1:]
+    raise ValueError(
+        "labels length must match decoder_input_ids or be longer by one"
+    )
+
+
+def _compute_span_accuracy(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    mask_positions: Optional[torch.Tensor],
+    mask_lengths: Optional[torch.Tensor],
+    pad_id: int,
+) -> Optional[float]:
+    if mask_positions is None or mask_lengths is None:
+        return None
+    if mask_positions.numel() == 0:
+        return None
+
+    # ensure we work on CPU tensors for easier iteration
+    pred_ids = logits.argmax(dim=-1)
+    labels_cpu = labels.detach().cpu()
+    preds_cpu = pred_ids.detach().cpu()
+    pos_cpu = mask_positions.detach().cpu()
+    len_cpu = mask_lengths.detach().cpu()
+
+    total = 0
+    correct = 0
+
+    batch_size = labels_cpu.size(0)
+    max_len = labels_cpu.size(1)
+
+    for b in range(batch_size):
+        positions = pos_cpu[b]
+        lengths = len_cpu[b]
+        for pos, span_len in zip(positions.tolist(), lengths.tolist()):
+            if pos < 0 or span_len <= 0:
+                continue
+            end = pos + span_len
+            if pos >= max_len or end > max_len:
+                continue
+            target_span = labels_cpu[b, pos:end]
+            if (target_span == pad_id).any():
+                continue
+            pred_span = preds_cpu[b, pos:end]
+            total += 1
+            if torch.equal(target_span, pred_span):
+                correct += 1
+
+    if total == 0:
+        return None
+    return float(correct / total)
+
+
+def sequence_loss_with_span_metrics(
+    logits: torch.Tensor,
+    labels: torch.Tensor,
+    *,
+    pad_id: int,
+    mask_positions: Optional[torch.Tensor] = None,
+    mask_lengths: Optional[torch.Tensor] = None,
+    compute_metrics: bool = False,
+) -> tuple[torch.Tensor, Dict[str, float]]:
+    """Compute cross-entropy loss and optional span-based accuracy."""
+
+    logits_for_loss, target = _align_logits_and_labels(logits, labels)
+    loss = F.cross_entropy(
+        logits_for_loss.reshape(-1, logits_for_loss.size(-1)),
+        target.reshape(-1),
+        ignore_index=pad_id,
+    )
+
+    metrics: Dict[str, float] = {}
+    if compute_metrics:
+        acc = _compute_span_accuracy(
+            logits_for_loss,
+            target,
+            mask_positions,
+            mask_lengths,
+            pad_id,
+        )
+        if acc is not None:
+            metrics["mask_accuracy"] = acc
+
+    return loss, metrics

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -27,7 +27,12 @@ def evaluate(model, dataloader, device, pad_id):
         inp = batch["input_ids"].to(device, non_blocking=True)
         att = batch["attention_mask"].to(device, non_blocking=True)
         lab = batch["labels"].to(device, non_blocking=True)
-        out = model(inp, att, labels=lab)
+        extra = {}
+        if "mask_positions" in batch:
+            extra["mask_positions"] = batch["mask_positions"].to(device, non_blocking=True)
+        if "mask_lengths" in batch:
+            extra["mask_lengths"] = batch["mask_lengths"].to(device, non_blocking=True)
+        out = model(inp, att, labels=lab, **extra)
         loss = out["loss"].item()
         tot += loss
         n += 1
@@ -136,9 +141,14 @@ def train_loop(
                 inp = batch["input_ids"].to(device, non_blocking=True)
                 att = batch["attention_mask"].to(device, non_blocking=True)
                 lab = batch["labels"].to(device, non_blocking=True)
+                extra = {}
+                if "mask_positions" in batch:
+                    extra["mask_positions"] = batch["mask_positions"].to(device, non_blocking=True)
+                if "mask_lengths" in batch:
+                    extra["mask_lengths"] = batch["mask_lengths"].to(device, non_blocking=True)
 
                 with autocast_ctx:
-                    out = model(inp, att, labels=lab)
+                    out = model(inp, att, labels=lab, **extra)
                     loss = out["loss"]
 
                 loss_to_backward = loss / grad_accum

--- a/tests/test_dataloaders.py
+++ b/tests/test_dataloaders.py
@@ -1,10 +1,55 @@
 from pathlib import Path
 import sys
 
-sys.path.append(str(Path(__file__).resolve().parents[1] / "src"))
+import torch
 
-from training.dataloaders import _infer_task
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.append(str(SRC_ROOT))
+
+from training.dataloaders import JsonlSeq2Seq, _infer_task, pad_collate
+from tokenizer.tokenizer_io import TokWrapper
 
 
 def test_infer_task_rdfcomp1_from_mask_marker():
     assert _infer_task("rdfcomp1.train.jsonl", "<MASK> some prompt") == "rdfcomp1"
+
+
+def test_jsonlseq2seq_entity_spans_present():
+    tok = TokWrapper(str(PROJECT_ROOT / "data" / "vocab" / "bpe.json"))
+    dataset = JsonlSeq2Seq(
+        str(PROJECT_ROOT / "data" / "processed" / "rdfcomp1.train.jsonl"),
+        tokenizer=tok,
+        max_len=64,
+        enable_entity_spans=True,
+    )
+    item = dataset[0]
+    # the first token should be <SOT> for rdfcomp1 examples
+    assert item["labels"][0].item() == tok.token_to_id("<SOT>")
+    assert item["mask_positions"].numel() == 1
+    assert item["mask_lengths"].numel() == 1
+    pos = item["mask_positions"][0].item()
+    span_len = item["mask_lengths"][0].item()
+    assert pos == 0
+    assert span_len > 0
+    expected_ids = tok.encode(dataset.items[0].target.strip())
+    assert item["labels"][1 : 1 + span_len].tolist() == expected_ids[:span_len]
+
+
+def test_pad_collate_adds_mask_tensors():
+    tok = TokWrapper(str(PROJECT_ROOT / "data" / "vocab" / "bpe.json"))
+    dataset = JsonlSeq2Seq(
+        str(PROJECT_ROOT / "data" / "processed" / "rdfcomp1.train.jsonl"),
+        tokenizer=tok,
+        max_len=64,
+        enable_entity_spans=True,
+    )
+    batch = [dataset[0], dataset[1]]
+    collated = pad_collate(batch, pad_id=tok.pad_id)
+    assert "mask_positions" in collated
+    assert "mask_lengths" in collated
+    assert collated["mask_positions"].dtype == torch.long
+    assert collated["mask_lengths"].dtype == torch.long
+    assert collated["mask_positions"].shape[0] == len(batch)
+    assert collated["mask_positions"].shape == collated["mask_lengths"].shape

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -1,0 +1,53 @@
+from pathlib import Path
+import sys
+
+import torch
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+SRC_ROOT = PROJECT_ROOT / "src"
+if str(SRC_ROOT) not in sys.path:
+    sys.path.append(str(SRC_ROOT))
+
+from model.losses import sequence_loss_with_span_metrics
+
+
+def _build_logits(vocab_size: int, correct_token: int, wrong: bool = False):
+    logits = torch.full((1, 1, vocab_size), -10.0)
+    target_token = (correct_token + 1) % vocab_size if wrong else correct_token
+    logits[0, 0, target_token] = 10.0
+    return logits
+
+
+def test_sequence_loss_with_span_accuracy_correct():
+    vocab_size = 8
+    labels = torch.tensor([[5, 3]])  # first token is decoder input, second is target
+    logits = _build_logits(vocab_size, correct_token=3)
+    mask_positions = torch.tensor([[0]])
+    mask_lengths = torch.tensor([[1]])
+    loss, metrics = sequence_loss_with_span_metrics(
+        logits,
+        labels,
+        pad_id=0,
+        mask_positions=mask_positions,
+        mask_lengths=mask_lengths,
+        compute_metrics=True,
+    )
+    assert torch.isfinite(loss)
+    assert metrics["mask_accuracy"] == 1.0
+
+
+def test_sequence_loss_with_span_accuracy_incorrect():
+    vocab_size = 8
+    labels = torch.tensor([[9, 2]])
+    logits = _build_logits(vocab_size, correct_token=2, wrong=True)
+    mask_positions = torch.tensor([[0]])
+    mask_lengths = torch.tensor([[1]])
+    _, metrics = sequence_loss_with_span_metrics(
+        logits,
+        labels,
+        pad_id=0,
+        mask_positions=mask_positions,
+        mask_lengths=mask_lengths,
+        compute_metrics=True,
+    )
+    assert metrics["mask_accuracy"] == 0.0


### PR DESCRIPTION
## Summary
- extract entity span positions for rdfcomp1 samples and expose them via the dataloader
- augment the transformer loss with optional span accuracy metrics and wire new flags through CLI and configs
- cover the new behaviour with dedicated unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e107acb0748331a2174b511c6134f2