### PR TITLE
Add single-batch overfit workflow to CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,20 @@ python -m scripts.eval_all --cfg configs/eval/baseline.yaml
 python -m src.cli evaluate --cfg configs/eval/baseline.yaml
 python -m src.cli predict --checkpoint checkpoints/baseline/best.pt \
     --tokenizer data/vocab/bpe.json --task text2rdf --input "Trama..."
+python -m scripts.sanity_overfit --cfg configs/train/baseline.yaml
 ```
+
+### 2.5 Sanity check: overfit di un singolo batch
+
+Il comando `src.cli overfit` (e lo script di comodo `python -m scripts.sanity_overfit`) forzano automaticamente:
+
+- `num_epochs = 1`
+- `max_steps = 1` (un solo aggiornamento dell'ottimizzatore)
+- `overfit_one_batch = true` (campiona un unico batch con `SubsetRandomSampler`)
+
+Questo consente di verificare rapidamente che il modello sia in grado di sovradattarsi a pochi esempi e che l'intera pipeline
+di training (tokenizer, dataloader, loop, logging) sia correttamente configurata. Sono comunque accettati override addizionali
+da CLI, ad esempio per puntare al sottoinsieme toy: `python -m scripts.sanity_overfit --cfg configs/train/baseline.yaml --toy`.
 
 ### 2.4 Toy set (debug rapido)
 

--- a/scripts/sanity_overfit.py
+++ b/scripts/sanity_overfit.py
@@ -1,0 +1,24 @@
+"""Utility per verificare rapidamente se il modello riesce ad overfittare un batch."""
+
+import argparse
+
+from src.cli import cmd_overfit
+from src.utils.config import add_common_overrides
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Sanity check: forza l'overfit su un singolo batch usando src.cli overfit",
+    )
+    add_common_overrides(parser)
+    return parser
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    cmd_overfit(args)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -114,6 +114,7 @@ def train_loop(
     best_step = 0
 
     stop_training = False
+    overfit_one_batch = bool(cfg.get("overfit_one_batch", False))
 
     wandb_cfg = cfg.get("wandb") or {}
     watch_model = bool(wandb_cfg.get("watch", False))
@@ -209,6 +210,9 @@ def train_loop(
                         wandb_logger(log_payload, step=global_step)
                     except Exception as exc:
                         tqdm.write(f"[wandb] log() failed: {exc}")
+
+                if overfit_one_batch:
+                    stop_training = True
 
                 if batch_idx >= steps_per_epoch or stop_training:
                     break


### PR DESCRIPTION
## Summary
- force the `overfit` CLI entrypoint to override epochs, steps, and enable a one-batch flag
- sample a single batch via `SubsetRandomSampler` and stop the training loop after the first batch when the flag is active
- expose a convenience script and document the streamlined sanity-overfit workflow in the README

## Testing
- python -m scripts.sanity_overfit --help

------
https://chatgpt.com/codex/tasks/task_e_68e125832ff08331a6627c3f8bc1a8f6