### PR TITLE
Add T5-style transformer option

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,19 @@ Vedi esempi in `configs/` per:
 - `decode/constrained.yaml` — vincoli leggeri per RDF
 - blocco `wandb:` — parametri di logging (project, entity, run_name, mode, tags, watch)
 
+### Nuove opzioni modello
+- `architecture`: scegli `"vanilla"` per mantenere l'encoder–decoder classico
+  (nn.Transformer/varianti MLA+RoPE) oppure `"t5"` per attivare blocchi T5 con LayerNorm
+  pre-attention, feed-forward GeGLU e bias posizionali relativi a bucket. La variante T5
+  applica automaticamente lo scaling `√d_model` sulle embedding e riutilizza un dropout
+  condiviso per encoder/decoder.
+- `relative_attention_num_buckets` e `relative_attention_max_distance`: controllano la
+  discretizzazione delle distanze per il bias relativo T5. Sono ignorati in modalità
+  "vanilla" ma diventano obbligatori quando `architecture="t5"`.
+- `layer_norm_epsilon`: epsilon numerico per le LayerNorm T5.
+- Quando `architecture="t5"` le opzioni `use_rope`, `use_mla` e `interleave_ratio` sono
+  disabilitate (sollevano errore in config misti).
+
 ---
 
 ## 4) Fase Dati (Step 1–3) — Design logico e contratti I/O

--- a/configs/train/baseline.yaml
+++ b/configs/train/baseline.yaml
@@ -6,12 +6,16 @@ tokenizer_file: "data/vocab/bpe.json"
 use_rope: false
 use_mla: false
 interleave_ratio: 0.0
+architecture: "vanilla"
 d_model: 384
 nhead: 6
 enc_layers: 3
 dec_layers: 3
 ff_dim: 1536
 dropout: 0.1
+relative_attention_num_buckets: 32
+relative_attention_max_distance: 128
+layer_norm_epsilon: 1.0e-6
 max_len: 256
 
 # span masking (disabilitato)

--- a/configs/train/mix_3322.yaml
+++ b/configs/train/mix_3322.yaml
@@ -23,12 +23,16 @@ datasets:
 use_rope: false
 use_mla: false
 interleave_ratio: 0.0
+architecture: "vanilla"
 d_model: 384
 nhead: 6
 enc_layers: 3
 dec_layers: 3
 ff_dim: 1536
 dropout: 0.1
+relative_attention_num_buckets: 32
+relative_attention_max_distance: 128
+layer_norm_epsilon: 1.0e-6
 max_len: 512
 
 # span masking per RDF Completion 1

--- a/configs/train/rope_on.yaml
+++ b/configs/train/rope_on.yaml
@@ -7,12 +7,16 @@ tokenizer_file: "data/vocab/bpe.json"
 use_rope: true
 use_mla: false
 interleave_ratio: 0.0
+architecture: "vanilla"
 d_model: 384
 nhead: 6
 enc_layers: 3
 dec_layers: 3
 ff_dim: 1536
 dropout: 0.1
+relative_attention_num_buckets: 32
+relative_attention_max_distance: 128
+layer_norm_epsilon: 1.0e-6
 max_len: 256
 
 # span masking (disabilitato per esperimento RoPE)

--- a/src/cli.py
+++ b/src/cli.py
@@ -30,14 +30,15 @@ def _coerce_cfg_types(cfg: dict):
         if k in cfg: cfg[k] = int(cfg[k])
 
     # float
-    for k in ("lr", "weight_decay", "dropout"):
-        if k in cfg: 
+    for k in ("lr", "weight_decay", "dropout", "layer_norm_epsilon"):
+        if k in cfg:
             try: _as_float(k)
             except: pass
     # int
     for k in ("warmup_steps", "batch_size", "num_epochs", "gradient_accumulation_steps",
               "d_model", "nhead", "enc_layers", "dec_layers",
-              "ff_dim", "max_len", "seed", "num_workers"):
+              "ff_dim", "max_len", "seed", "num_workers",
+              "relative_attention_num_buckets", "relative_attention_max_distance"):
         if k in cfg:
             try: _as_int(k)
             except: pass
@@ -261,6 +262,10 @@ def cmd_train(args):
         interleave_ratio=float(cfg.get("interleave_ratio", 0.0)),
         max_position_embeddings=int(cfg.get("max_len", 256)),
         compute_span_metrics=compute_span_metrics,
+        architecture=cfg.get("architecture", "vanilla"),
+        relative_attention_num_buckets=int(cfg.get("relative_attention_num_buckets", 32)),
+        relative_attention_max_distance=int(cfg.get("relative_attention_max_distance", 128)),
+        layer_norm_epsilon=float(cfg.get("layer_norm_epsilon", 1e-6)),
     ).to(device)
 
     # 6) training loop

--- a/src/eval/evaluate.py
+++ b/src/eval/evaluate.py
@@ -66,6 +66,10 @@ def _load_model_from_checkpoint(
         interleave_ratio=float(saved_cfg.get("interleave_ratio", 0.0)),
         max_position_embeddings=int(saved_cfg.get("max_len", 256)),
         compute_span_metrics=bool(saved_cfg.get("compute_span_metrics", False)),
+        architecture=str(saved_cfg.get("architecture", "vanilla")),
+        relative_attention_num_buckets=int(saved_cfg.get("relative_attention_num_buckets", 32)),
+        relative_attention_max_distance=int(saved_cfg.get("relative_attention_max_distance", 128)),
+        layer_norm_epsilon=float(saved_cfg.get("layer_norm_epsilon", 1e-6)),
     ).to(device)
     model.load_state_dict(ckpt["model"])
     model.eval()

--- a/src/model/layers.py
+++ b/src/model/layers.py
@@ -448,3 +448,383 @@ class CustomTransformer(nn.Module):
             )
         return self.decoder_norm(output)
 
+
+class RelativePositionBias(nn.Module):
+    """Implements T5-style relative position bias with bucketing."""
+
+    def __init__(
+        self,
+        num_heads: int,
+        num_buckets: int = 32,
+        max_distance: int = 128,
+        *,
+        bidirectional: bool = True,
+    ) -> None:
+        super().__init__()
+        if num_buckets <= 0:
+            raise ValueError("num_buckets must be positive")
+        if num_heads <= 0:
+            raise ValueError("num_heads must be positive")
+        self.num_heads = int(num_heads)
+        self.num_buckets = int(num_buckets)
+        self.max_distance = int(max_distance)
+        self.bidirectional = bool(bidirectional)
+        self.relative_attention_bias = nn.Embedding(self.num_buckets, self.num_heads)
+
+    def _relative_position_bucket(self, relative_position: torch.Tensor) -> torch.Tensor:
+        num_buckets = self.num_buckets
+        max_distance = max(1, self.max_distance)
+        relative_buckets = torch.zeros_like(relative_position, dtype=torch.long)
+
+        if self.bidirectional:
+            num_buckets //= 2
+            relative_buckets += (relative_position > 0).to(torch.long) * num_buckets
+            relative_position = relative_position.abs()
+        else:
+            relative_position = -torch.min(relative_position, torch.zeros_like(relative_position))
+
+        max_exact = max(1, num_buckets // 2)
+        is_small = relative_position < max_exact
+        log_ratio = math.log(max_distance / max_exact) if max_distance > max_exact else 1.0
+        large_pos = max_exact + (
+            torch.log(relative_position.float() / max_exact + 1e-6) / log_ratio
+        ) * (num_buckets - max_exact)
+        large_pos = large_pos.long()
+        large_pos = torch.min(large_pos, torch.full_like(large_pos, num_buckets - 1))
+        relative_buckets += torch.where(is_small, relative_position, large_pos)
+        return relative_buckets
+
+    def forward(
+        self,
+        query_length: int,
+        key_length: int,
+        *,
+        device: torch.device,
+        dtype: torch.dtype,
+    ) -> torch.Tensor:
+        context_position = torch.arange(query_length, dtype=torch.long, device=device)[:, None]
+        memory_position = torch.arange(key_length, dtype=torch.long, device=device)[None, :]
+        relative_position = memory_position - context_position
+        bucket = self._relative_position_bucket(relative_position)
+        values = self.relative_attention_bias(bucket)
+        values = values.permute(2, 0, 1).unsqueeze(0)
+        return values.to(dtype)
+
+
+class T5Attention(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        num_heads: int,
+        dropout: float,
+        *,
+        relative_bias: Optional[RelativePositionBias] = None,
+    ) -> None:
+        super().__init__()
+        if d_model % num_heads != 0:
+            raise ValueError("d_model must be divisible by num_heads")
+        self.d_model = d_model
+        self.num_heads = num_heads
+        self.head_dim = d_model // num_heads
+        self.relative_bias = relative_bias
+        self.q = nn.Linear(d_model, d_model, bias=False)
+        self.k = nn.Linear(d_model, d_model, bias=False)
+        self.v = nn.Linear(d_model, d_model, bias=False)
+        self.out = nn.Linear(d_model, d_model, bias=False)
+        self.dropout = nn.Dropout(dropout)
+
+    def _reshape(self, tensor: torch.Tensor) -> torch.Tensor:
+        batch, seq_len, dim = tensor.size()
+        tensor = tensor.view(batch, seq_len, self.num_heads, self.head_dim)
+        return tensor.transpose(1, 2)
+
+    def _merge(self, tensor: torch.Tensor) -> torch.Tensor:
+        batch, heads, seq_len, dim = tensor.size()
+        return tensor.transpose(1, 2).reshape(batch, seq_len, heads * dim)
+
+    def _prepare_attention_mask(self, mask: Optional[torch.Tensor], target: torch.Tensor) -> Optional[torch.Tensor]:
+        if mask is None:
+            return None
+        if mask.dim() == 2:
+            mask = mask.unsqueeze(0).unsqueeze(0)
+        elif mask.dim() == 3:
+            mask = mask.unsqueeze(1)
+        elif mask.dim() != 4:
+            raise ValueError("Unsupported attention mask dimensions")
+        if mask.size(-1) != target.size(-1):
+            mask = mask.expand(-1, -1, -1, target.size(-1))
+        return mask
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor] = None,
+        key_value_states: Optional[torch.Tensor] = None,
+        key_padding_mask: Optional[torch.Tensor] = None,
+        position_bias: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        query = self._reshape(self.q(hidden_states))
+        if key_value_states is None:
+            key_states = hidden_states
+            value_states = hidden_states
+        else:
+            key_states = key_value_states
+            value_states = key_value_states
+        key = self._reshape(self.k(key_states))
+        value = self._reshape(self.v(value_states))
+
+        scores = torch.matmul(query, key.transpose(-2, -1)) / math.sqrt(self.head_dim)
+
+        if self.relative_bias is not None and position_bias is None:
+            position_bias = self.relative_bias(
+                query_length=query.size(-2),
+                key_length=key.size(-2),
+                device=query.device,
+                dtype=query.dtype,
+            )
+        if position_bias is not None:
+            scores = scores + position_bias
+
+        if key_padding_mask is not None:
+            mask = key_padding_mask.unsqueeze(1).unsqueeze(2)
+            scores = scores.masked_fill(mask, torch.finfo(scores.dtype).min)
+
+        if attention_mask is not None:
+            attn_mask = self._prepare_attention_mask(attention_mask, scores)
+            if attn_mask.dtype == torch.bool:
+                scores = scores.masked_fill(attn_mask, torch.finfo(scores.dtype).min)
+            else:
+                scores = scores + attn_mask.to(scores.dtype)
+
+        attn_weights = torch.softmax(scores, dim=-1)
+        attn_weights = self.dropout(attn_weights)
+        attn_output = torch.matmul(attn_weights, value)
+        attn_output = self._merge(attn_output)
+        return self.out(attn_output)
+
+
+class T5FeedForward(nn.Module):
+    def __init__(self, d_model: int, dim_feedforward: int, dropout: float) -> None:
+        super().__init__()
+        self.wi = nn.Linear(d_model, dim_feedforward * 2, bias=False)
+        self.wo = nn.Linear(dim_feedforward, d_model, bias=False)
+        self.dropout = nn.Dropout(dropout)
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        wi = self.wi(x)
+        gate, value = wi.chunk(2, dim=-1)
+        gated = F.gelu(gate) * value
+        return self.dropout(self.wo(gated))
+
+
+class T5EncoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        nhead: int,
+        dim_feedforward: int,
+        dropout: float,
+        *,
+        layer_norm_epsilon: float,
+        relative_bias: Optional[RelativePositionBias],
+    ) -> None:
+        super().__init__()
+        self.self_attn = T5Attention(
+            d_model,
+            nhead,
+            dropout,
+            relative_bias=relative_bias,
+        )
+        self.layer_norm = nn.LayerNorm(d_model, eps=layer_norm_epsilon)
+        self.ff_layer_norm = nn.LayerNorm(d_model, eps=layer_norm_epsilon)
+        self.feed_forward = T5FeedForward(d_model, dim_feedforward, dropout)
+        self.dropout = nn.Dropout(dropout)
+        self.relative_bias = relative_bias
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor] = None,
+        key_padding_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        normed = self.layer_norm(hidden_states)
+        position_bias = None
+        if self.relative_bias is not None:
+            position_bias = self.relative_bias(
+                query_length=normed.size(1),
+                key_length=normed.size(1),
+                device=normed.device,
+                dtype=normed.dtype,
+            )
+        attn_out = self.self_attn(
+            normed,
+            attention_mask=attention_mask,
+            key_padding_mask=key_padding_mask,
+            position_bias=position_bias,
+        )
+        hidden_states = hidden_states + self.dropout(attn_out)
+        hidden_states = hidden_states + self.dropout(self.feed_forward(self.ff_layer_norm(hidden_states)))
+        return hidden_states
+
+
+class T5DecoderLayer(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        nhead: int,
+        dim_feedforward: int,
+        dropout: float,
+        *,
+        layer_norm_epsilon: float,
+        self_relative_bias: Optional[RelativePositionBias],
+    ) -> None:
+        super().__init__()
+        self.self_attn = T5Attention(
+            d_model,
+            nhead,
+            dropout,
+            relative_bias=self_relative_bias,
+        )
+        self.cross_attn = T5Attention(d_model, nhead, dropout, relative_bias=None)
+        self.self_attn_layer_norm = nn.LayerNorm(d_model, eps=layer_norm_epsilon)
+        self.cross_attn_layer_norm = nn.LayerNorm(d_model, eps=layer_norm_epsilon)
+        self.ff_layer_norm = nn.LayerNorm(d_model, eps=layer_norm_epsilon)
+        self.feed_forward = T5FeedForward(d_model, dim_feedforward, dropout)
+        self.dropout = nn.Dropout(dropout)
+        self.relative_bias = self_relative_bias
+
+    def forward(
+        self,
+        hidden_states: torch.Tensor,
+        memory: torch.Tensor,
+        *,
+        self_attn_mask: Optional[torch.Tensor] = None,
+        self_key_padding_mask: Optional[torch.Tensor] = None,
+        cross_key_padding_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        normed = self.self_attn_layer_norm(hidden_states)
+        position_bias = None
+        if self.relative_bias is not None:
+            position_bias = self.relative_bias(
+                query_length=normed.size(1),
+                key_length=normed.size(1),
+                device=normed.device,
+                dtype=normed.dtype,
+            )
+        self_attn_out = self.self_attn(
+            normed,
+            attention_mask=self_attn_mask,
+            key_padding_mask=self_key_padding_mask,
+            position_bias=position_bias,
+        )
+        hidden_states = hidden_states + self.dropout(self_attn_out)
+
+        normed_cross = self.cross_attn_layer_norm(hidden_states)
+        cross_out = self.cross_attn(
+            normed_cross,
+            key_value_states=memory,
+            key_padding_mask=cross_key_padding_mask,
+        )
+        hidden_states = hidden_states + self.dropout(cross_out)
+
+        hidden_states = hidden_states + self.dropout(self.feed_forward(self.ff_layer_norm(hidden_states)))
+        return hidden_states
+
+
+class T5Transformer(nn.Module):
+    def __init__(
+        self,
+        d_model: int,
+        nhead: int,
+        num_encoder_layers: int,
+        num_decoder_layers: int,
+        dim_feedforward: int,
+        dropout: float,
+        *,
+        relative_attention_num_buckets: int,
+        relative_attention_max_distance: int,
+        layer_norm_epsilon: float = 1e-6,
+    ) -> None:
+        super().__init__()
+        encoder_bias = RelativePositionBias(
+            nhead,
+            num_buckets=relative_attention_num_buckets,
+            max_distance=relative_attention_max_distance,
+            bidirectional=True,
+        )
+        decoder_bias = RelativePositionBias(
+            nhead,
+            num_buckets=relative_attention_num_buckets,
+            max_distance=relative_attention_max_distance,
+            bidirectional=False,
+        )
+        self.encoder_layers = nn.ModuleList(
+            [
+                T5EncoderLayer(
+                    d_model,
+                    nhead,
+                    dim_feedforward,
+                    dropout,
+                    layer_norm_epsilon=layer_norm_epsilon,
+                    relative_bias=encoder_bias,
+                )
+                for _ in range(num_encoder_layers)
+            ]
+        )
+        self.decoder_layers = nn.ModuleList(
+            [
+                T5DecoderLayer(
+                    d_model,
+                    nhead,
+                    dim_feedforward,
+                    dropout,
+                    layer_norm_epsilon=layer_norm_epsilon,
+                    self_relative_bias=decoder_bias,
+                )
+                for _ in range(num_decoder_layers)
+            ]
+        )
+        self.encoder_norm = nn.LayerNorm(d_model, eps=layer_norm_epsilon)
+        self.decoder_norm = nn.LayerNorm(d_model, eps=layer_norm_epsilon)
+        self.dropout = nn.Dropout(dropout)
+
+    def encode(
+        self,
+        src: torch.Tensor,
+        *,
+        attention_mask: Optional[torch.Tensor] = None,
+        key_padding_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        output = src
+        for layer in self.encoder_layers:
+            output = layer(
+                output,
+                attention_mask=attention_mask,
+                key_padding_mask=key_padding_mask,
+            )
+        output = self.encoder_norm(output)
+        return self.dropout(output)
+
+    def decode(
+        self,
+        tgt: torch.Tensor,
+        memory: torch.Tensor,
+        *,
+        self_attn_mask: Optional[torch.Tensor] = None,
+        self_key_padding_mask: Optional[torch.Tensor] = None,
+        cross_key_padding_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        output = tgt
+        for layer in self.decoder_layers:
+            output = layer(
+                output,
+                memory,
+                self_attn_mask=self_attn_mask,
+                self_key_padding_mask=self_key_padding_mask,
+                cross_key_padding_mask=cross_key_padding_mask,
+            )
+        output = self.decoder_norm(output)
+        return self.dropout(output)
+

--- a/src/model/transformer.py
+++ b/src/model/transformer.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import torch
 import torch.nn as nn
 
-from .layers import CustomTransformer, SinusoidalPE
+import math
+
+from .layers import CustomTransformer, SinusoidalPE, T5Transformer
 from .losses import sequence_loss_with_span_metrics
 
 
@@ -27,37 +29,64 @@ class TinySeq2Seq(nn.Module):
         interleave_ratio: float = 0.0,
         max_position_embeddings: int = 2048,
         compute_span_metrics: bool = False,
+        architecture: str = "vanilla",
+        relative_attention_num_buckets: int = 32,
+        relative_attention_max_distance: int = 128,
+        layer_norm_epsilon: float = 1e-6,
     ) -> None:
         super().__init__()
         self.pad_id = pad_id
         self.compute_span_metrics = bool(compute_span_metrics)
+        arch = (architecture or "vanilla").lower()
+        if arch not in {"vanilla", "t5"}:
+            raise ValueError("architecture must be 'vanilla' or 't5'")
+        self.architecture = arch
         self.emb = nn.Embedding(vocab_size, d_model, padding_idx=pad_id)
-        self.pe = None if use_rope else SinusoidalPE(d_model, max_len=max_position_embeddings)
+        self.embedding_scale = math.sqrt(d_model) if self.architecture == "t5" else 1.0
+        self.dropout_layer = nn.Dropout(dropout)
 
-        self._use_custom = bool(use_rope or use_mla or interleave_ratio > 0.0)
-        if self._use_custom:
-            self.tfm = CustomTransformer(
+        if self.architecture == "t5":
+            if use_rope or use_mla or abs(float(interleave_ratio)) > 1e-8:
+                raise ValueError("T5 architecture does not support RoPE/MLA/interleave options")
+            self.pe = None
+            self.tfm = T5Transformer(
                 d_model=d_model,
                 nhead=nhead,
                 num_encoder_layers=num_encoder_layers,
                 num_decoder_layers=num_decoder_layers,
                 dim_feedforward=dim_feedforward,
                 dropout=dropout,
-                use_mla=use_mla,
-                interleave_ratio=interleave_ratio,
-                use_rope=use_rope,
-                max_position_embeddings=max_position_embeddings,
+                relative_attention_num_buckets=relative_attention_num_buckets,
+                relative_attention_max_distance=relative_attention_max_distance,
+                layer_norm_epsilon=layer_norm_epsilon,
             )
+            self._use_custom = True
         else:
-            self.tfm = nn.Transformer(
-                d_model=d_model,
-                nhead=nhead,
-                num_encoder_layers=num_encoder_layers,
-                num_decoder_layers=num_decoder_layers,
-                dim_feedforward=dim_feedforward,
-                dropout=dropout,
-                batch_first=True,
-            )
+            self.pe = None if use_rope else SinusoidalPE(d_model, max_len=max_position_embeddings)
+            self._use_custom = bool(use_rope or use_mla or interleave_ratio > 0.0)
+            if self._use_custom:
+                self.tfm = CustomTransformer(
+                    d_model=d_model,
+                    nhead=nhead,
+                    num_encoder_layers=num_encoder_layers,
+                    num_decoder_layers=num_decoder_layers,
+                    dim_feedforward=dim_feedforward,
+                    dropout=dropout,
+                    use_mla=use_mla,
+                    interleave_ratio=interleave_ratio,
+                    use_rope=use_rope,
+                    max_position_embeddings=max_position_embeddings,
+                )
+            else:
+                self.tfm = nn.Transformer(
+                    d_model=d_model,
+                    nhead=nhead,
+                    num_encoder_layers=num_encoder_layers,
+                    num_decoder_layers=num_decoder_layers,
+                    dim_feedforward=dim_feedforward,
+                    dropout=dropout,
+                    batch_first=True,
+                )
         self.lm_head = nn.Linear(d_model, vocab_size, bias=False)
         if tie_embeddings:
             self.lm_head.weight = self.emb.weight
@@ -77,9 +106,11 @@ class TinySeq2Seq(nn.Module):
         mask_lengths: torch.Tensor | None = None,
     ) -> dict[str, torch.Tensor | None]:
         device = input_ids.device
-        enc = self.emb(input_ids)
-        if self.pe is not None:
+        enc = self.emb(input_ids) * self.embedding_scale
+        if self.architecture != "t5" and self.pe is not None:
             enc = self.pe(enc)
+        if self.architecture == "t5":
+            enc = self.dropout_layer(enc)
         src_kpm = attention_mask == 0
 
         if decoder_input_ids is None:
@@ -91,13 +122,24 @@ class TinySeq2Seq(nn.Module):
 
         y_inp = decoder_input_ids
 
-        dec = self.emb(y_inp)
-        if self.pe is not None:
+        dec = self.emb(y_inp) * self.embedding_scale
+        if self.architecture != "t5" and self.pe is not None:
             dec = self.pe(dec)
+        if self.architecture == "t5":
+            dec = self.dropout_layer(dec)
         tgt_mask = self._subsequent_mask(y_inp.size(1), device)
         tgt_kpm = y_inp == self.pad_id
 
-        if self._use_custom:
+        if self.architecture == "t5":
+            mem = self.tfm.encode(enc, key_padding_mask=src_kpm)
+            out = self.tfm.decode(
+                dec,
+                mem,
+                self_attn_mask=tgt_mask,
+                self_key_padding_mask=tgt_kpm,
+                cross_key_padding_mask=src_kpm,
+            )
+        elif self._use_custom:
             mem = self.tfm.encode(enc, src_key_padding_mask=src_kpm)
             out = self.tfm.decode(
                 dec,

--- a/tests/test_transformer_variants.py
+++ b/tests/test_transformer_variants.py
@@ -81,3 +81,38 @@ def test_interleave_ratio_clamped():
     logits = out["logits"]
     assert logits.shape[1] == labels.size(1) - 1
     assert torch.all(torch.isfinite(logits))
+
+
+@torch.no_grad()
+def test_tinyseq2seq_t5_forward():
+    torch.manual_seed(2)
+    vocab_size = 48
+    model = TinySeq2Seq(
+        vocab_size=vocab_size,
+        d_model=64,
+        nhead=4,
+        num_encoder_layers=2,
+        num_decoder_layers=2,
+        dim_feedforward=128,
+        dropout=0.1,
+        pad_id=0,
+        architecture="t5",
+        relative_attention_num_buckets=16,
+        relative_attention_max_distance=64,
+    )
+
+    input_ids = torch.randint(1, vocab_size, (2, 6))
+    input_ids[0, -1] = 0
+    attention_mask = torch.ones_like(input_ids)
+    attention_mask[0, -1] = 0
+
+    labels = torch.randint(1, vocab_size, (2, 7))
+    labels[:, -1] = 0
+
+    out = model(input_ids, attention_mask, labels=labels)
+    logits = out["logits"]
+    loss = out["loss"]
+
+    assert logits.shape == (input_ids.size(0), labels.size(1) - 1, vocab_size)
+    assert torch.all(torch.isfinite(logits))
+    assert loss is not None and torch.isfinite(loss)


### PR DESCRIPTION
## Summary
- implement T5-inspired encoder/decoder blocks with pre-norm attention, GeGLU MLPs, and relative position bias tables
- extend TinySeq2Seq, configs, and CLI/eval wiring with an `architecture` selector and T5-specific hyperparameters plus documentation
- add a regression test covering the new T5 variant

## Testing
- pytest tests/test_transformer_variants.py
- python -m src.cli overfit --cfg configs/train/baseline.yaml --toy

------
https://chatgpt.com/codex/tasks/task_e_68e1385cb4d4833182233464db2131a7