### PR TITLE
Add alias-driven evaluation config and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ nanosocrates/
 │  │  ├─ toy.yaml                # remapping verso data/processed/toy
 │  │  └─ wikipedia.yaml          # API REST, lingua, timeout
 │  ├─ eval/
-│  │  └─ baseline.yaml           # esempio completo di valutazione
+│  │  └─ multitask_default.yaml # preset di valutazione multitask (alias-driven)
 │  ├─ tokenizer/
 │  │  └─ bpe_default.yaml            # addestramento tokenizer + token speciali
 │  └─ train/
@@ -91,8 +91,10 @@ pip install -r requirements.txt
    ```
 5. **Valuta il checkpoint** (report JSON + metriche aggregate)
    ```bash
-   python -m src.run evaluate --cfg configs/eval/baseline.yaml --output reports/baseline_eval.json
-   # legacy wrapper → python -m scripts.eval_all --cfg configs/eval/baseline.yaml
+   python -m src.run evaluate --cfg configs/eval/multitask_default.yaml \
+       --override checkpoint=checkpoints/multitask_default/best.pt \
+       --output reports/multitask_default_eval.json
+   # legacy wrapper → python -m scripts.eval_all --cfg configs/eval/multitask_default.yaml
    ```
 
 ### 2.3 Tutorial — sottoinsieme toy (20 film)
@@ -106,7 +108,7 @@ pip install -r requirements.txt
 3. Esegui training e valutazione puntando ai nuovi file con il flag `--toy`:
    ```bash
    python -m src.run train --cfg configs/train/multitask_default.yaml --toy
-   python -m scripts.eval_all --cfg configs/eval/baseline.yaml --toy
+   python -m scripts.eval_all --cfg configs/eval/multitask_default.yaml --toy
    ```
 
 ### 2.4 Tutorial — sanity check (overfit di un batch)
@@ -146,14 +148,17 @@ pip install -r requirements.txt
    fallisce viene eseguito automaticamente il fallback in modalità offline.
 2. Per loggare anche la valutazione usa lo stesso approccio:
    ```bash
-   python -m src.run evaluate --cfg configs/eval/baseline.yaml --override \
-       wandb.mode=online wandb.project=nanosocrates-demo --output reports/baseline_eval.json
+   python -m src.run evaluate --cfg configs/eval/multitask_default.yaml --override \
+       checkpoint=checkpoints/multitask_default/best.pt \
+       wandb.mode=online wandb.project=nanosocrates-demo --output reports/multitask_default_eval.json
    ```
    Le metriche vengono appiattite tramite `src.utils.wandb_utils.flatten_eval_metrics`
    e inviate come singolo step alla run già configurata.
 3. Per eseguire la valutazione dal RUN unificato mantenendo gli override:
    ```bash
-   python -m src.run evaluate --cfg configs/eval/baseline.yaml --override wandb.mode=online wandb.project=nanosocrates-demo --output reports/baseline_eval.json
+   python -m src.run evaluate --cfg configs/eval/multitask_default.yaml --override \
+       checkpoint=checkpoints/multitask_default/best.pt \
+       wandb.mode=online wandb.project=nanosocrates-demo --output reports/multitask_default_eval.json
    ```
 
 ---
@@ -264,18 +269,26 @@ per gli split `val`/`test` e aggrega i risultati per task.
 
 ### 8.1 Configurazione & script
 
-Il file `configs/eval/baseline.yaml` mostra un esempio completo di configurazione
-con percorsi `val`/`test` per ciascun task, parametri di decoding e destinazione
-del report JSON. Per eseguire una valutazione completa:
+Il file `configs/eval/multitask_default.yaml` mostra un esempio completo di
+configurazione con percorsi `val`/`test` per ciascun task, parametri di decoding
+e destinazione del report JSON. Il campo `checkpoint` è impostato sul
+segnaposto `<<override-me>>`: indica agli script di passare il path corretto via
+`--override` (o di risolverlo tramite l'alias dichiarato in `model_alias`).
+Per eseguire una valutazione completa sul mix multitask T5:
 
 ```bash
-python -m src.run evaluate --cfg configs/eval/baseline.yaml --output reports/eval.json
+python -m src.run evaluate --cfg configs/eval/multitask_default.yaml \
+    --override checkpoint=checkpoints/multitask_default/best.pt --output reports/eval.json
 ```
 
 Il comando genera un report strutturato (stampato a terminale e salvato su disco)
 ed effettua l'eventuale logging su Weights & Biases se abilitato nel config.
 Per retrocompatibilità rimane disponibile anche `python -m scripts.eval_all`,
-che reindirizza automaticamente verso il subcomando `evaluate`.
+che reindirizza automaticamente verso il subcomando `evaluate` e sfrutta
+`model_alias` per impostare l'override se non già specificato. Usa
+`--model-alias rope_on` per puntare al checkpoint RoPE (`checkpoints/rope_on/best.pt`).
+Gli alias predefiniti includono anche `mix` (sinonimo di `multitask_default`) e
+`baseline` per il vecchio encoder–decoder sinusoidale.
 
 ### 8.2 Inference manuale
 
@@ -283,9 +296,9 @@ Per testare rapidamente il modello su un input specifico puoi usare il
 subcomando `predict` oppure lo script di esempio `scripts/predict_example.py`:
 
 ```bash
-python -m src.run predict --checkpoint checkpoints/baseline/best.pt --tokenizer data/vocab/bpe.json --task text2rdf --input "Plot ..."
+python -m src.run predict --checkpoint checkpoints/multitask_default/best.pt --tokenizer data/vocab/bpe.json --task text2rdf --input "Plot ..."
 
-python -m scripts.predict_example --checkpoint checkpoints/baseline/best.pt --tokenizer data/vocab/bpe.json --task rdf2text --input "<SOT> ... <RDF2Text>"
+python -m scripts.predict_example --checkpoint checkpoints/multitask_default/best.pt --tokenizer data/vocab/bpe.json --task rdf2text --input "<SOT> ... <RDF2Text>"
 ```
 
 Il flag `--task` aggiunge automaticamente il marker speciale previsto dal
@@ -368,6 +381,7 @@ Questa tabella raccoglie le chiavi YAML più rilevanti (sezioni `train/` ed
 ### 12.5 Config valutazione (`configs/eval/*.yaml`)
 
 - `checkpoint`, `tokenizer_file`, `device`: cosa caricare e dove inferire.
+- `model_alias`: mapping rapido verso i checkpoint salvati (`mix`, `rope_on`, ...).
 - `batch_size`, `num_workers`: throughput inferenza.
 - `decoding.max_new_tokens`: limite della generazione autoregressiva.
 - `enable_entity_spans`: calcola metriche MASK se il checkpoint le supporta.

--- a/configs/eval/multitask_default.yaml
+++ b/configs/eval/multitask_default.yaml
@@ -1,10 +1,12 @@
-checkpoint: "checkpoints/baseline/best.pt"
+model_alias: "multitask_default"
+checkpoint: "<<override-me>>"  # usa --override checkpoint=... oppure aggiorna CHECKPOINT_ALIASES
+
 tokenizer_file: "data/vocab/bpe.json"
 max_len: 256
 batch_size: 8
 num_workers: 2
 device: "cuda"
-output_json: "reports/baseline_eval.json"
+output_json: "reports/multitask_default_eval.json"
 
 decoding:
   max_new_tokens: 160

--- a/scripts/eval_all.py
+++ b/scripts/eval_all.py
@@ -1,14 +1,115 @@
-"""Compatibilità retroattiva per la vecchia CLI di valutazione."""
+"""Compatibilità retroattiva per la vecchia CLI di valutazione con alias checkpoint."""
 from __future__ import annotations
 
+from pathlib import Path
 import sys
+from typing import List, Optional, Tuple
+
+from src.utils.config import CHECKPOINT_ALIASES, load_yaml
+
+
+def _pop_model_alias(argv: List[str]) -> Tuple[Optional[str], List[str]]:
+    alias: Optional[str] = None
+    cleaned: List[str] = []
+    skip_next = False
+    for idx, token in enumerate(argv):
+        if skip_next:
+            skip_next = False
+            continue
+        if token == "--model-alias":
+            if idx + 1 < len(argv):
+                alias = argv[idx + 1]
+                skip_next = True
+            continue
+        if token.startswith("--model-alias="):
+            alias = token.split("=", 1)[1]
+            continue
+        cleaned.append(token)
+    return alias, cleaned
+
+
+def _find_cfg_path(argv: List[str]) -> Optional[Path]:
+    for idx, token in enumerate(argv):
+        if token == "--cfg" and idx + 1 < len(argv):
+            return Path(argv[idx + 1])
+        if token.startswith("--cfg="):
+            return Path(token.split("=", 1)[1])
+    return None
+
+
+def _config_alias(cfg_path: Optional[Path]) -> Optional[str]:
+    if cfg_path is None or not cfg_path.exists():
+        return None
+    try:
+        payload = load_yaml(str(cfg_path))
+    except Exception:  # pragma: no cover - caricare YAML è best effort
+        return None
+    if isinstance(payload, dict):
+        alias = payload.get("model_alias")
+        if isinstance(alias, str) and alias.strip():
+            return alias.strip()
+    return None
+
+
+def _contains_checkpoint_override(argv: List[str]) -> bool:
+    pending_override = False
+    for token in argv:
+        if token == "--override":
+            pending_override = True
+            continue
+        if token.startswith("--"):
+            pending_override = False
+        if pending_override and token.startswith("checkpoint="):
+            return True
+        if token.startswith("checkpoint="):
+            return True
+    return False
+
+
+def _inject_checkpoint_override(argv: List[str], checkpoint: str) -> List[str]:
+    if not checkpoint:
+        return argv
+    updated = list(argv)
+    for idx, token in enumerate(updated):
+        if token == "--override":
+            insert_at = idx + 1
+            while insert_at < len(updated) and not updated[insert_at].startswith("--"):
+                insert_at += 1
+            updated.insert(insert_at, f"checkpoint={checkpoint}")
+            return updated
+    updated.extend(["--override", f"checkpoint={checkpoint}"])
+    return updated
+
+
+def _ensure_evaluate_command(argv: List[str]) -> List[str]:
+    if not argv or argv[0] != "evaluate":
+        return ["evaluate", *argv]
+    return argv
 
 
 def main() -> None:
     """Reindirizza verso `python -m src.run evaluate` preservando gli argomenti."""
 
-    if len(sys.argv) < 2 or sys.argv[1] != "evaluate":
-        sys.argv.insert(1, "evaluate")
+    forwarded = sys.argv[1:]
+    alias, forwarded = _pop_model_alias(forwarded)
+    cfg_path = _find_cfg_path(forwarded)
+    alias = alias or _config_alias(cfg_path)
+
+    if alias:
+        alias = alias.strip()
+        resolved = CHECKPOINT_ALIASES.get(alias)
+        if resolved is None:
+            print(
+                f"[eval_all] Alias modello '{alias}' non riconosciuto: "
+                "passa --override checkpoint=... manualmente.",
+                file=sys.stderr,
+            )
+        elif not _contains_checkpoint_override(forwarded):
+            forwarded = _inject_checkpoint_override(forwarded, resolved)
+
+    forwarded = _ensure_evaluate_command(forwarded)
+
+    sys.argv = [sys.argv[0], *forwarded]
 
     from src.run import main as run_main
 

--- a/src/run.py
+++ b/src/run.py
@@ -25,6 +25,7 @@ from src.utils.config import (
     apply_overrides,
     apply_toy_paths,
     load_yaml,
+    resolve_checkpoint_reference,
 )
 from src.utils.wandb_utils import flatten_eval_metrics, maybe_init_wandb
 
@@ -108,6 +109,7 @@ def _prepare_config(args: argparse.Namespace) -> Dict[str, Any]:
         cfg = apply_toy_paths(cfg)
         LOGGER.info("[toy] uso i dataset compatti in data/processed/toy")
     cfg = apply_overrides(cfg, args.override)
+    cfg = resolve_checkpoint_reference(cfg)
     return cfg
 
 

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,9 +1,25 @@
-"""
-Caricamento semplice di YAML in dict.
-"""
+"""Caricamento semplice di YAML in dict e utility per i config."""
 from __future__ import annotations
-from typing import Any, Dict
-import yaml, argparse
+
+import argparse
+from typing import Dict
+
+import yaml
+
+CHECKPOINT_PLACEHOLDER = "<<override-me>>"
+"""Segnaposto usato nei config di valutazione quando manca un checkpoint reale."""
+
+CHECKPOINT_ALIASES = {
+    # Multitask T5 con mixing standard.
+    "multitask_default": "checkpoints/multitask_default/best.pt",
+    "mix": "checkpoints/multitask_default/best.pt",
+    # Encoder-decoder vanilla con RoPE abilitato.
+    "rope_on": "checkpoints/rope_on/best.pt",
+    "rope": "checkpoints/rope_on/best.pt",
+    # Alias storico per il preset vanilla senza RoPE.
+    "baseline": "checkpoints/baseline/best.pt",
+}
+"""Mappa alias→path per i checkpoint salvati più comuni."""
 
 def _transform_processed_paths(node, prefix: str, toy_prefix: str):
     if isinstance(node, dict):
@@ -20,6 +36,34 @@ def _transform_processed_paths(node, prefix: str, toy_prefix: str):
 def load_yaml(path: str):
     with open(path, "r", encoding="utf-8") as f:
         return yaml.safe_load(f)
+
+
+def resolve_checkpoint_reference(cfg: Dict[str, object]) -> Dict[str, object]:
+    """Sostituisce il placeholder del checkpoint sfruttando l'alias quando possibile."""
+
+    if not isinstance(cfg, dict) or "checkpoint" not in cfg:
+        return cfg
+
+    checkpoint = cfg.get("checkpoint")
+    alias = cfg.get("model_alias")
+
+    if isinstance(checkpoint, str) and checkpoint not in {"", CHECKPOINT_PLACEHOLDER}:
+        return cfg
+
+    if isinstance(alias, str) and alias.strip():
+        key = alias.strip()
+        resolved = CHECKPOINT_ALIASES.get(key)
+        if resolved:
+            cfg["checkpoint"] = resolved
+            return cfg
+        raise ValueError(
+            f"Alias modello '{key}' non riconosciuto: passa --override checkpoint=... oppure "
+            "aggiorna CHECKPOINT_ALIASES."
+        )
+
+    raise ValueError(
+        "Config di valutazione senza checkpoint: usa --override checkpoint=... oppure definisci 'model_alias'."
+    )
 
 def add_common_overrides(ap: argparse.ArgumentParser):
     ap.add_argument("--cfg", required=True, help="path yaml (es. configs/train/multitask_default.yaml)")


### PR DESCRIPTION
## Summary
- rename the baseline evaluation preset to `configs/eval/multitask_default.yaml` and add a checkpoint placeholder plus `model_alias`
- resolve evaluation checkpoints via shared alias mapping and update the legacy wrapper to inject overrides automatically
- refresh README examples to use the new preset and document how to target different checkpoints (mix vs. RoPE)

## Testing
- python -m compileall src scripts

------
https://chatgpt.com/codex/tasks/task_e_68ea98324ff083319d7343cfdcbf83f0