### PR TITLE
Ensure film is subject in normalised triples

### DIFF
--- a/src/data/pairing.py
+++ b/src/data/pairing.py
@@ -2,8 +2,8 @@
 Pairing & filtro qualità:
 - Unisce triple (per film) e testo (intro) in un unico record.
 - rimuove duplicati di triple, scarta film con testo mancante o poche triple.
-- normalizza le triple in forma (s, p, o), sia per relazioni uscenti che entranti.
-Output: {"film", "text", "triples": [(s, p, o), ...]}
+- normalizza le triple in forma (film, p, o) così che il film resti sempre il soggetto.
+Output: {"film", "text", "triples": [(film, p, o), ...]}
 """
 
 from __future__ import annotations
@@ -18,17 +18,17 @@ def pair_and_filter(
     texts_stream: Iterable[dict],
     min_triples: int = 3,
 ) -> Iterator[dict]:
-    """Join triple and text streams keeping only well-formed film records."""
+    """Join triple and text streams keeping only well-formed film records.
+
+    The returned triples always expose the film as the explicit subject,
+    regardless of the original triple direction provided upstream.
+    """
     triples_by_film: Dict[str, List[Tuple[str, str, str]]] = defaultdict(list)
     for r in triples_stream:
-        direction = r.get("dir", "out")
-        if direction == "in":
-            triple = (r["o"], r["p"], r["film"])
-        else:
-            triple = (r["film"], r["p"], r["o"])
-        # We normalise triples so that the film is always the subject. For
-        # "incoming" edges we swap subject and object to keep the format
-        # consistent with decoder expectations.
+        triple = (r["film"], r["p"], r["o"])
+        # We normalise triples so that the film is always the subject. Incoming
+        # edges are conceptually rewritten to keep a consistent (film, predicate,
+        # object) structure for downstream consumers.
         triples_by_film[r["film"]].append(triple)
 
     texts_by_film: Dict[str, str] = {}

--- a/tests/data/test_pairing.py
+++ b/tests/data/test_pairing.py
@@ -1,0 +1,28 @@
+import pathlib
+import sys
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.data.pairing import pair_and_filter
+
+
+def test_pair_and_filter_normalises_incoming_triples() -> None:
+    triples_stream = [
+        {"film": "film_1", "p": "hasDirector", "o": "Person:A", "dir": "out"},
+        {"film": "film_1", "p": "starring", "o": "Person:B", "dir": "in"},
+    ]
+    texts_stream = [
+        {"film": "film_1", "text": "Film intro."},
+    ]
+
+    paired = list(pair_and_filter(triples_stream, texts_stream, min_triples=1))
+
+    assert len(paired) == 1
+    record = paired[0]
+    assert record["film"] == "film_1"
+    assert record["triples"] == [
+        ("film_1", "hasDirector", "Person:A"),
+        ("film_1", "starring", "Person:B"),
+    ]


### PR DESCRIPTION
## Summary
- normalise `pair_and_filter` so that incoming triples also emit the film as the explicit subject and refresh its documentation
- add a regression test covering mixed-direction triples to guard the normalisation behaviour
- rebuild the processed datasets so every triple subject now matches the owning film

## Testing
- pytest
- PYTHONPATH=. python scripts/build_dataset.py --config configs/data/build.yaml --dbp data/raw/dbpedia_triples.jsonl --wiki data/raw/wikipedia_intro.jsonl --outdir data/processed --emit_tasks


------
https://chatgpt.com/codex/tasks/task_e_68ed57e556888331a6a71b462d9db540