### PR TITLE
Align scheduler stepping with optimizer updates

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -203,8 +203,20 @@ def run_training(cfg: Dict[str, Any], *, overfit: bool = False) -> None:
         shuffle=False,
     )
 
-    steps_per_epoch = max(1, math.ceil(len(train_dataset) / batch_size))
-    total_steps = steps_per_epoch * int(cfg.get("num_epochs", 1))
+    num_epochs = int(cfg.get("num_epochs", 1))
+    grad_accum_steps = max(1, int(cfg.get("gradient_accumulation_steps", 1)))
+
+    try:
+        batches_per_epoch = len(train_loader)
+    except TypeError:
+        dataset_length = len(train_dataset)
+        batches_per_epoch = math.ceil(dataset_length / batch_size) if batch_size > 0 else 0
+
+    if batches_per_epoch == 0 or num_epochs <= 0:
+        total_steps = 0
+    else:
+        optimizer_steps_per_epoch = math.ceil(batches_per_epoch / grad_accum_steps)
+        total_steps = optimizer_steps_per_epoch * num_epochs
 
     model = _build_model(cfg, tokenizer)
     optimizer = _build_optimizer(cfg, model)
@@ -232,7 +244,7 @@ def run_training(cfg: Dict[str, Any], *, overfit: bool = False) -> None:
         val_loader=val_loader,
         device=device,
         use_amp=use_amp,
-        grad_accum_steps=int(cfg.get("gradient_accumulation_steps", 1)),
+        grad_accum_steps=grad_accum_steps,
         log_every_n_steps=int(cfg.get("log_every_n_steps", 50)),
         checkpoint_path=str(checkpoint_path),
         early_stopping_patience=int(cfg.get("early_stopping", {}).get("patience", 5)),
@@ -241,7 +253,6 @@ def run_training(cfg: Dict[str, Any], *, overfit: bool = False) -> None:
         wandb_run=run,
     )
 
-    num_epochs = int(cfg.get("num_epochs", 1))
     if num_epochs <= 0:
         LOGGER.info("num_epochs=0: pipeline configurata, nessun batch elaborato.")
     else:

--- a/src/training/loop.py
+++ b/src/training/loop.py
@@ -151,18 +151,16 @@ class TrainingLoop:
 
             metric_value = val_metrics.get(self.es_metric)
 
-            if self.scheduler:
-                # Some schedulers use metrics (e.g., ReduceLROnPlateau)
-                if isinstance(self.scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
-                    if metric_value is None:
-                        logger.warning(
-                            "Scheduler expects metric '%s' but it was missing; skipping scheduler step for this epoch.",
-                            self.es_metric,
-                        )
-                    else:
-                        self.scheduler.step(metric_value)
+            if self.scheduler and isinstance(
+                self.scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau
+            ):
+                if metric_value is None:
+                    logger.warning(
+                        "Scheduler expects metric '%s' but it was missing; skipping scheduler step for this epoch.",
+                        self.es_metric,
+                    )
                 else:
-                    self.scheduler.step()
+                    self.scheduler.step(metric_value)
 
             # Log metrics to wandb
             if self.wandb_run:
@@ -243,6 +241,7 @@ class TrainingLoop:
                     self.scaler.update()
                 else:
                     self.optimizer.step()
+                self._step_batch_scheduler()
                 self.optimizer.zero_grad(set_to_none=True)
 
             # Update progress bar with smoothed loss
@@ -280,6 +279,7 @@ class TrainingLoop:
                 self.scaler.update()
             else:
                 self.optimizer.step()
+            self._step_batch_scheduler()
             self.optimizer.zero_grad(set_to_none=True)
 
         avg_loss = total_loss / num_batches
@@ -356,6 +356,13 @@ class TrainingLoop:
             logger.info(f"No improvement. Early stopping counter: {self.es_counter}/{self.es_patience}")
 
         return self.es_counter >= self.es_patience
+
+    def _step_batch_scheduler(self) -> None:
+        """Advance per-step schedulers keeping pace with optimizer updates."""
+        if self.scheduler and not isinstance(
+            self.scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau
+        ):
+            self.scheduler.step()
 
     def _transfer_batch_to_device(self, batch: dict[str, torch.Tensor]) -> dict[str, torch.Tensor]:
         """Moves a batch of data to the configured device."""

--- a/tests/training/test_loop.py
+++ b/tests/training/test_loop.py
@@ -24,6 +24,19 @@ class _CountingSGD(torch.optim.SGD):
         return super().step(closure)
 
 
+class _CountingScheduler(torch.optim.lr_scheduler.LambdaLR):
+    """Learning-rate scheduler that tracks calls to ``step``."""
+
+    def __init__(self, optimizer):
+        self.step_calls = 0
+        super().__init__(optimizer, lr_lambda=lambda _: 1.0)
+        self.step_calls = 0
+
+    def step(self, epoch=None):  # type: ignore[override]
+        self.step_calls += 1
+        return super().step(epoch)
+
+
 class _DummyDataset(Dataset):
     def __init__(self, length: int):
         self.length = length
@@ -76,3 +89,34 @@ def test_optimizer_steps_flush_pending_gradients():
     assert (
         optimizer.step_calls == expected_steps
     ), f"Expected {expected_steps} optimizer steps, got {optimizer.step_calls}"
+
+
+def test_scheduler_steps_match_optimizer_steps():
+    grad_accum_steps = 3
+    dataset_length = 5
+
+    train_dataset = _DummyDataset(dataset_length)
+    train_loader = DataLoader(train_dataset, batch_size=1, shuffle=False)
+    val_loader = DataLoader(_DummyDataset(1), batch_size=1)
+
+    model = _DummyModel()
+    optimizer = _CountingSGD(model.parameters(), lr=0.1)
+    scheduler = _CountingScheduler(optimizer)
+
+    loop = TrainingLoop(
+        model=model,
+        optimizer=optimizer,
+        train_loader=train_loader,
+        val_loader=val_loader,
+        scheduler=scheduler,
+        device="cpu",
+        use_amp=False,
+        grad_accum_steps=grad_accum_steps,
+        log_every_n_steps=10,
+    )
+
+    loop._train_epoch(epoch=1)
+
+    expected_steps = math.ceil(dataset_length / grad_accum_steps)
+    assert optimizer.step_calls == expected_steps
+    assert scheduler.step_calls == expected_steps


### PR DESCRIPTION
## Summary
- call learning-rate schedulers that operate per-step after each optimizer update and restrict ReduceLROnPlateau stepping to the epoch loop
- compute scheduler total_steps from the dataloader length and gradient accumulation factor before constructing the scheduler
- add coverage ensuring scheduler.step invocations match optimizer updates

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed6754d91c83319b51fd02346d3050