### PR TITLE
Compact RDF inputs and improve decoding diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,34 @@ che reindirizza automaticamente verso il subcomando `evaluate` e sfrutta
 Gli alias predefiniti includono anche `mix` (sinonimo di `multitask_default`) e
 `baseline` per il vecchio encoder–decoder sinusoidale.
 
+#### Anteprima delle predizioni
+
+Per diagnosticare errori di valutazione è possibile chiedere a `evaluate`
+di salvare un campione di input/target/predizione. Aggiungi la sezione
+`preview` nel config (o usa `--override preview.limit=5`) per ottenere un
+riepilogo per task nel report JSON e, opzionalmente, dei file JSONL con
+le predizioni grezze:
+
+```yaml
+preview:
+  limit: 5          # massimo numero di esempi mostrati per ciascun task
+  per_task: true    # se false applica il limite sull'intero dataset
+  output_dir: "reports/previews"  # (facoltativo) salva i record su disco
+```
+
+Nel report, la chiave `preview` contiene l'elenco dei campioni per task,
+includendo input originale, target atteso, output normalizzato e un flag
+`exact_match`. I record ora riportano anche il numero di token per input,
+target e predizione, oltre a eventuali `warnings` (es. `empty_prediction`
+o `input_truncated`).
+
+Quando `output_dir` è impostato, ogni combinazione `split`/`task` produce
+un file `*.jsonl` facilmente consultabile o caricabile in spreadsheet
+per analisi mirate. Inoltre la sezione `diagnostics` del report riepiloga
+le lunghezze medie/min/max degli input, quante predizioni risultano
+vuote e quali esempi saturano il `max_len`, facilitando l'individuazione
+di dataset problematici.
+
 ### 8.2 Inference manuale
 
 Per testare rapidamente il modello su un input specifico puoi usare il
@@ -292,7 +320,10 @@ python -m scripts.predict_example --checkpoint checkpoints/multitask_default/bes
 ```
 
 Il flag `--task` aggiunge automaticamente il marker speciale previsto dal
-dataset se non già presente nell'input.
+dataset se non già presente nell'input. L'output del comando è ora un
+JSON compatto che riporta input originale, prompt effettivo e statistiche
+di lunghezza della predizione; aggiungi `--output reports/pred.json`
+per salvare lo stesso payload su disco.
 
 ---
 

--- a/configs/tokenizer/bpe_default.yaml
+++ b/configs/tokenizer/bpe_default.yaml
@@ -8,6 +8,8 @@ special_tokens:
   - "<SUBJ>"
   - "<PRED>"
   - "<OBJ>"
+  - "<OBJ_LIST>"
+  - "|"
   - "<RDF2Text>"
   - "<Text2RDF>"
   - "<CONTINUERDF>"

--- a/src/decoding/base.py
+++ b/src/decoding/base.py
@@ -18,7 +18,12 @@ from __future__ import annotations
 
 from typing import Optional
 
+import logging
+
 import torch
+
+
+LOGGER = logging.getLogger(__name__)
 
 
 def _select_start_token_id(tok, eot_id: Optional[int] = None) -> int:
@@ -48,6 +53,9 @@ def greedy_decode(
     input_text: str,
     max_new_tokens: int = 128,
     device: str = "cpu",
+    *,
+    min_new_tokens: int = 1,
+    debug: bool = False,
 ):
     """Esegue il decoding greedy restituendo gli ID generati.
 
@@ -67,21 +75,48 @@ def greedy_decode(
     start_id = _select_start_token_id(tok, eot_id)
     y = torch.tensor([[start_id]], dtype=torch.long, device=device)
 
-    for _ in range(max_new_tokens):
+    for step in range(max_new_tokens):
         out = model(inp, att, decoder_input_ids=y)
-        next_id = out["logits"][:, -1, :].argmax(-1, keepdim=True)  # greedy
+        logits_step = out["logits"][:, -1, :]
+        generated_len = y.size(1) - 1
+        if eot_id is not None and generated_len < int(max(0, min_new_tokens)):
+            logits_step = logits_step.clone()
+            min_val = torch.finfo(logits_step.dtype).min
+            logits_step[..., int(eot_id)] = min_val
+        next_id = logits_step.argmax(-1, keepdim=True)
         y = torch.cat([y, next_id], dim=1)
-        if eot_id is not None and int(next_id.item()) == int(eot_id):
+        token_id = int(next_id.item())
+        if debug:
+            LOGGER.debug("[decode] step=%d token_id=%d", step, token_id)
+        if eot_id is not None and token_id == int(eot_id):
             break
-    return y[0].tolist()
+    ids = y[0].tolist()
+    if debug:
+        LOGGER.debug("[decode] generated ids=%s", ids)
+    return ids
 
 
 @torch.no_grad()
 def decode_to_text(model, tok, input_text: str, **kwargs) -> str:
     """Wrapper pratico che nasconde la rimozione del token iniziale."""
 
-    ids = greedy_decode(model, tok, input_text, **kwargs)
+    return_ids = bool(kwargs.pop("return_ids", False))
+    debug = bool(kwargs.pop("debug", False))
+    min_new_tokens = int(kwargs.pop("min_new_tokens", 1))
+    ids = greedy_decode(
+        model,
+        tok,
+        input_text,
+        min_new_tokens=min_new_tokens,
+        debug=debug,
+        **kwargs,
+    )
     start_id = _select_start_token_id(tok)
     if ids and ids[0] == start_id:
         ids = ids[1:]
-    return tok.tk.decode(ids)
+    text = tok.tk.decode(ids)
+    if debug:
+        LOGGER.debug("[decode] decoded text='%s'", text)
+    if return_ids:
+        return text, ids
+    return text

--- a/src/eval/evaluate.py
+++ b/src/eval/evaluate.py
@@ -2,23 +2,24 @@
 
 from __future__ import annotations
 
+import json
+import logging
 import os
-from collections import defaultdict
+from collections import Counter, defaultdict
 from functools import partial
-from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional
+from pathlib import Path
+from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 import torch
 from torch.utils.data import DataLoader
 
 from src.decoding.base import decode_to_text
-from src.eval.metrics import (
-    compute_accuracy,
-    compute_text_generation_metrics,
-    compute_triple_metrics,
-)
+from src.eval.metrics import compute_accuracy, compute_text_generation_metrics, compute_triple_metrics
 from src.model.transformer import TinySeq2Seq
 from src.tokenizer.tokenizer_io import TokWrapper
 from src.training.dataloaders import JsonlSeq2Seq, pad_collate
+
+LOGGER = logging.getLogger(__name__)
 
 def _select_device(want: Optional[str]) -> str:
     """Sceglie "cuda" solo se disponibile, altrimenti ripiega su CPU."""
@@ -36,6 +37,32 @@ def _normalise_text(text: str) -> str:
         return ""
     cleaned = [tok for tok in text.replace("\n", " ").split() if tok and tok != "<pad>"]
     return " ".join(cleaned).strip()
+
+
+def _summarise_lengths(lengths: Iterable[int]) -> Dict[str, float]:
+    """Calcola statistiche robuste (min, max, media, mediana) su una sequenza di lunghezze."""
+
+    values = [int(max(0, length)) for length in lengths]
+    if not values:
+        return {"count": 0, "min": 0, "max": 0, "mean": 0.0, "median": 0.0, "zeros": 0}
+
+    values.sort()
+    count = len(values)
+    zeros = sum(1 for value in values if value == 0)
+    mean = float(sum(values) / count)
+    if count % 2:
+        median = float(values[count // 2])
+    else:
+        median = float(values[count // 2 - 1] + values[count // 2]) / 2.0
+
+    return {
+        "count": count,
+        "min": int(values[0]),
+        "max": int(values[-1]),
+        "mean": mean,
+        "median": median,
+        "zeros": int(zeros),
+    }
 
 
 def _load_model_from_checkpoint(
@@ -138,12 +165,20 @@ def _generate_predictions(
     dataset: JsonlSeq2Seq,
     device: str,
     max_new_tokens: int,
-) -> tuple[List[str], List[str], List[str]]:
+    *,
+    normalise: bool = True,
+    return_raw: bool = False,
+    min_new_tokens: int = 1,
+    debug_generation: bool = False,
+) -> tuple[List[str], List[str], List[str]] | tuple[List[str], List[str], List[str], List[str], List[str], List[List[int]]]:
     """Genera predizioni greedy restituendo anche i task di provenienza."""
 
     predictions: List[str] = []
     references: List[str] = []
+    raw_predictions: List[str] = []
+    raw_references: List[str] = []
     tasks: List[str] = []
+    token_sequences: List[List[int]] = []
 
     for ex in dataset.items:
         source: str = ""
@@ -180,17 +215,152 @@ def _generate_predictions(
         if not source:
             continue
 
-        pred = decode_to_text(
+        pred, token_ids = decode_to_text(
             model,
             tokenizer,
             source,
             max_new_tokens=max_new_tokens,
             device=device,
+            min_new_tokens=min_new_tokens,
+            debug=debug_generation,
+            return_ids=True,
         )
-        predictions.append(_normalise_text(pred))
-        references.append(_normalise_text(target))
+        raw_predictions.append(pred)
+        raw_references.append(target)
+        token_sequences.append(token_ids)
+        if normalise:
+            predictions.append(_normalise_text(pred))
+            references.append(_normalise_text(target))
+        else:
+            predictions.append(pred)
+            references.append(target)
         tasks.append(str(task_name or "unknown"))
+    if return_raw:
+        return predictions, references, tasks, raw_predictions, raw_references, token_sequences
     return predictions, references, tasks
+
+
+def _extract_example_fields(example) -> Tuple[str, str, str, Optional[str]]:
+    """Return raw input/target/task/film strings from a dataset item."""
+
+    if isinstance(example, Mapping):
+        source = str(
+            example.get("raw_input")
+            or example.get("input")
+            or example.get("source")
+            or ""
+        )
+        target = str(
+            example.get("raw_target")
+            or example.get("target")
+            or example.get("output")
+            or example.get("label")
+            or ""
+        )
+        task_name = str(example.get("task") or example.get("task_name") or "")
+        film = example.get("film")
+    else:
+        source = str(
+            getattr(example, "input_text", None)
+            or getattr(example, "input", None)
+            or ""
+        )
+        target = str(
+            getattr(example, "target_text", None)
+            or getattr(example, "target", None)
+            or getattr(example, "label", None)
+            or ""
+        )
+        task_name = str(getattr(example, "task", "") or "")
+        film = getattr(example, "film", None)
+    return source, target, task_name, film
+
+
+def _build_preview_records(
+    dataset: JsonlSeq2Seq,
+    predictions: Sequence[str],
+    references: Sequence[str],
+    raw_predictions: Sequence[str],
+    tasks: Sequence[str],
+    token_ids: Sequence[Sequence[int]],
+    *,
+    limit: int,
+    per_task: bool = True,
+) -> Dict[str, List[Dict[str, object]]]:
+    """Create a limited set of per-task preview records for debugging."""
+
+    if limit <= 0:
+        return {}
+
+    previews: Dict[str, List[Dict[str, object]]] = defaultdict(list)
+    counters: Counter[str] = Counter()
+    total_added = 0
+
+    for idx, (pred, ref, raw_pred, task_tag, token_seq) in enumerate(
+        zip(predictions, references, raw_predictions, tasks, token_ids)
+    ):
+        bucket = str(task_tag or "unknown")
+        if per_task:
+            if counters[bucket] >= limit:
+                continue
+        else:
+            if total_added >= limit:
+                break
+        source, target, dataset_task, film = _extract_example_fields(dataset.items[idx])
+        example = dataset.items[idx]
+        record: Dict[str, object] = {
+            "index": idx,
+            "task": bucket,
+            "dataset_task": dataset_task,
+            "film": film,
+            "input": source,
+            "target": target,
+            "prediction": raw_pred,
+            "prediction_normalised": pred,
+            "target_normalised": ref,
+            "exact_match": bool(pred == ref),
+            "input_tokens": len(getattr(example, "input_ids", []) or []),
+            "target_tokens": len(getattr(example, "label_ids", []) or []),
+            "prediction_chars": len(raw_pred.strip()),
+            "prediction_tokens": len(raw_pred.split()),
+            "prediction_token_ids": list(token_seq),
+        }
+        warnings: List[str] = []
+        if not raw_pred.strip():
+            warnings.append("empty_prediction")
+        if len(getattr(example, "input_ids", [])) >= getattr(dataset, "max_len", 0) > 0:
+            warnings.append("input_truncated")
+        if len(getattr(example, "label_ids", [])) >= getattr(dataset, "max_len", 0) > 0:
+            warnings.append("target_truncated")
+        if warnings:
+            record["warnings"] = warnings
+        previews[bucket].append(record)
+        counters[bucket] += 1
+        total_added += 1
+    return dict(previews)
+
+
+def _write_preview_files(
+    previews: Mapping[str, List[Dict[str, object]]],
+    *,
+    output_dir: Path,
+    split: str,
+    task: str,
+) -> Optional[Path]:
+    """Persist preview records to disk and return the output path."""
+
+    if not previews:
+        return None
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+    preview_path = output_dir / f"{split}_{task}.jsonl"
+    with preview_path.open("w", encoding="utf-8") as f:
+        for task_name, records in previews.items():
+            for record in records:
+                payload = {"group": task_name, **record}
+                json.dump(payload, f, ensure_ascii=False)
+                f.write("\n")
+    return preview_path
 
 
 def _group_by_task(
@@ -258,6 +428,37 @@ def evaluate_from_config(config: Mapping[str, object]) -> Dict[str, object]:
     max_len = int(config.get("max_len", saved_cfg.get("max_len", 256)))
     decode_cfg = config.get("decoding") or {}
     max_new_tokens = int(decode_cfg.get("max_new_tokens", max_len))
+    min_new_tokens_raw = decode_cfg.get("min_new_tokens", 1)
+    try:
+        min_new_tokens = max(0, int(min_new_tokens_raw))
+    except (TypeError, ValueError):
+        min_new_tokens = 1
+    debug_generation_raw = decode_cfg.get(
+        "debug_generation",
+        decode_cfg.get("debug_token_ids", decode_cfg.get("debug", False)),
+    )
+    if isinstance(debug_generation_raw, str):
+        debug_generation = debug_generation_raw.lower() not in {"false", "0", "no"}
+    else:
+        debug_generation = bool(debug_generation_raw)
+
+    preview_cfg = config.get("preview") or {}
+    preview_limit_raw = preview_cfg.get("limit", config.get("preview_samples", 0))
+    try:
+        preview_limit = int(preview_limit_raw)
+    except (TypeError, ValueError):
+        preview_limit = 0
+    per_task = preview_cfg.get("per_task", True)
+    if isinstance(per_task, str):
+        per_task = per_task.lower() not in {"false", "0", "no"}
+    else:
+        per_task = bool(per_task)
+    preview_output_dir_raw = (
+        preview_cfg.get("output_dir")
+        or preview_cfg.get("dir")
+        or config.get("preview_output_dir")
+    )
+    preview_output_dir = Path(preview_output_dir_raw) if preview_output_dir_raw else None
 
     batch_size = int(config.get("batch_size", 8))
     num_workers = int(config.get("num_workers", 0))
@@ -305,9 +506,32 @@ def evaluate_from_config(config: Mapping[str, object]) -> Dict[str, object]:
                 pin_memory=pin_memory,
             )
             loss = _compute_loss(model, dataloader, device)
-            preds, refs, task_tags = _generate_predictions(
-                model, tokenizer, dataset, device, max_new_tokens
-            )
+            want_preview = preview_limit > 0
+            if want_preview:
+                preds, refs, task_tags, raw_preds, raw_refs, token_ids = _generate_predictions(
+                    model,
+                    tokenizer,
+                    dataset,
+                    device,
+                    max_new_tokens,
+                    return_raw=True,
+                    min_new_tokens=min_new_tokens,
+                    debug_generation=debug_generation,
+                )
+            else:
+                preds, refs, task_tags = _generate_predictions(
+                    model,
+                    tokenizer,
+                    dataset,
+                    device,
+                    max_new_tokens,
+                    return_raw=False,
+                    min_new_tokens=min_new_tokens,
+                    debug_generation=debug_generation,
+                )
+                raw_preds = preds
+                raw_refs = refs
+                token_ids = [[] for _ in preds]
             grouped = _group_by_task(preds, refs, task_tags)
             metrics_payload: Dict[str, object] = {}
             for t_name, bucket in grouped.items():
@@ -320,12 +544,91 @@ def evaluate_from_config(config: Mapping[str, object]) -> Dict[str, object]:
             if not metrics_payload:
                 metrics_payload[task_name] = {"samples": len(dataset)}
 
+            previews = {}
+            if want_preview:
+                previews = _build_preview_records(
+                    dataset,
+                    preds,
+                    refs,
+                    raw_preds,
+                    task_tags,
+                    token_ids,
+                    limit=preview_limit,
+                    per_task=per_task,
+                )
+
+            input_token_lengths = [len(example.input_ids) for example in dataset.items]
+            target_token_lengths = [len(example.label_ids) for example in dataset.items]
+            prediction_char_lengths = [len(pred.strip()) for pred in raw_preds]
+            prediction_token_lengths = [len(pred.split()) for pred in raw_preds]
+
+            diagnostics: Dict[str, object] = {
+                "input_tokens": _summarise_lengths(input_token_lengths),
+                "target_tokens": _summarise_lengths(target_token_lengths),
+                "prediction_chars": _summarise_lengths(prediction_char_lengths),
+                "prediction_tokens": _summarise_lengths(prediction_token_lengths),
+                "inputs_truncated": int(
+                    sum(1 for length in input_token_lengths if length >= dataset.max_len)
+                ),
+                "targets_truncated": int(
+                    sum(1 for length in target_token_lengths if length >= dataset.max_len)
+                ),
+            }
+
+            try:
+                unique_inputs = len({example.input_text for example in dataset.items})
+            except TypeError:
+                unique_inputs = len(dataset.items)
+            diagnostics["unique_inputs"] = int(unique_inputs)
+            diagnostics["duplicate_inputs"] = int(len(dataset) - unique_inputs)
+
+            if dataset.items:
+                longest_input_idx = max(
+                    range(len(dataset.items)),
+                    key=lambda i: len(dataset.items[i].input_ids),
+                )
+                longest_example = dataset.items[longest_input_idx]
+                diagnostics["longest_input_index"] = int(longest_input_idx)
+                diagnostics["longest_input_tokens"] = int(len(longest_example.input_ids))
+                diagnostics["longest_input_chars"] = int(len(longest_example.input_text))
+                diagnostics["longest_input_film"] = longest_example.film
+
+            empty_predictions = diagnostics["prediction_chars"]["zeros"]
+            total_predictions = diagnostics["prediction_chars"]["count"]
+            if total_predictions:
+                diagnostics["empty_prediction_ratio"] = float(
+                    empty_predictions / total_predictions
+                )
+            if empty_predictions:
+                LOGGER.warning(
+                    "Lo split %s del task %s ha prodotto %d predizioni vuote su %d esempi (%.1f%%).",
+                    split,
+                    task_name,
+                    empty_predictions,
+                    total_predictions,
+                    100.0 * empty_predictions / total_predictions if total_predictions else 0.0,
+                )
+
             split_payload["tasks"][task_name] = {
                 "path": str(path),
                 "loss": float(loss),
                 "num_samples": len(dataset),
                 "metrics": metrics_payload,
+                "diagnostics": diagnostics,
             }
+            if previews:
+                split_payload["tasks"][task_name]["preview"] = previews
+                if preview_output_dir is not None:
+                    preview_file = _write_preview_files(
+                        previews,
+                        output_dir=preview_output_dir,
+                        split=split,
+                        task=task_name,
+                    )
+                    if preview_file is not None:
+                        split_payload["tasks"][task_name]["preview_file"] = str(
+                            preview_file
+                        )
             weighted_loss += loss * len(dataset)
             total_samples += len(dataset)
 

--- a/src/run.py
+++ b/src/run.py
@@ -7,6 +7,7 @@ import json
 import logging
 import math
 import random
+import sys
 from pathlib import Path
 from typing import Any, Dict
 
@@ -14,7 +15,8 @@ import numpy as np
 import torch
 from tokenizers import Tokenizer
 
-from src.eval.evaluate import evaluate_from_config
+from src.decoding.base import decode_to_text
+from src.eval.evaluate import evaluate_from_config, load_model_and_tokenizer
 from src.data.builders import build_and_cache_datasets
 from src.model.transformer import TinySeq2Seq
 from src.training.dataloaders import create_multitask_dataloader
@@ -28,8 +30,16 @@ from src.utils.config import (
     resolve_checkpoint_reference,
 )
 from src.utils.wandb_utils import flatten_eval_metrics, maybe_init_wandb
+from src.tokenizer.tokenizer_io import ensure_runtime_special_tokens
 
 LOGGER = logging.getLogger(__name__)
+
+TASK_MARKERS = {
+    "text2rdf": "<Text2RDF>",
+    "rdf2text": "<RDF2Text>",
+    "rdfcomp2": "<CONTINUERDF>",
+    "rdfcomp1": "<MASK>",
+}
 
 
 def _get_pad_id(tokenizer: Tokenizer) -> int:
@@ -170,6 +180,7 @@ def run_training(cfg: Dict[str, Any], *, overfit: bool = False) -> None:
     if not tokenizer_path:
         raise ValueError("Specificare 'tokenizer_file' nel config di training.")
     tokenizer = Tokenizer.from_file(str(tokenizer_path))
+    ensure_runtime_special_tokens(tokenizer)
 
     dataset_payload = build_and_cache_datasets(cfg, tokenizer)
     train_dataset = dataset_payload["train"]
@@ -318,6 +329,62 @@ def cmd_evaluate(args: argparse.Namespace) -> None:
                 LOGGER.warning("Chiusura wandb fallita: %s", exc)
 
 
+def _prepare_predict_input(text: str, task: str | None) -> str:
+    """Attach the task marker to *text* when necessary for decoding."""
+    text = text.strip()
+    if task:
+        marker = TASK_MARKERS.get(task)
+        if marker and marker not in text:
+            if task == "rdfcomp1" and "<MASK>" not in text:
+                text = f"{text} <MASK>".strip()
+            else:
+                text = f"{text} {marker}".strip()
+    return text
+
+
+def cmd_predict(args: argparse.Namespace) -> None:
+    """Entry point for the ``predict`` sub-command."""
+    overrides: Dict[str, Any] = {}
+    if getattr(args, "model_override", None):
+        overrides = apply_overrides({}, args.model_override)
+
+    model, tokenizer, device, _ = load_model_and_tokenizer(
+        args.tokenizer,
+        args.checkpoint,
+        device=args.device,
+        overrides=overrides,
+    )
+
+    prepared_input = _prepare_predict_input(args.input, args.task)
+    prediction, token_ids = decode_to_text(
+        model,
+        tokenizer,
+        prepared_input,
+        max_new_tokens=args.max_new_tokens,
+        device=device,
+        return_ids=True,
+    )
+    result = {
+        "task": args.task,
+        "input": args.input,
+        "prepared_input": prepared_input,
+        "prediction": prediction,
+        "prediction_token_ids": token_ids,
+        "prediction_length_chars": len(prediction.strip()),
+        "prediction_length_tokens": len(prediction.split()),
+    }
+
+    indent = 2 if sys.stdout.isatty() else None
+    print(json.dumps(result, ensure_ascii=False, indent=indent))
+
+    if getattr(args, "output", None):
+        output_path = Path(args.output)
+        output_path.parent.mkdir(parents=True, exist_ok=True)
+        with output_path.open("w", encoding="utf-8") as f:
+            json.dump(result, f, ensure_ascii=False, indent=2)
+            f.write("\n")
+
+
 def build_parser() -> argparse.ArgumentParser:
     """Create the top-level CLI parser with the train/overfit/evaluate commands."""
     parser = argparse.ArgumentParser(description="Pipeline di training NanoSocrates")
@@ -333,6 +400,25 @@ def build_parser() -> argparse.ArgumentParser:
     add_common_overrides(p_eval)
     p_eval.add_argument("--output", help="File JSON per salvare il report", default=None)
 
+    p_predict = sub.add_parser("predict", help="Genera una predizione per un singolo input")
+    p_predict.add_argument("--checkpoint", required=True)
+    p_predict.add_argument("--tokenizer", required=True)
+    p_predict.add_argument("--input", required=True, help="Input testuale o RDF linearizzato")
+    p_predict.add_argument("--task", choices=sorted(TASK_MARKERS))
+    p_predict.add_argument("--device", default="cuda")
+    p_predict.add_argument("--max-new-tokens", type=int, default=128)
+    p_predict.add_argument(
+        "--model-override",
+        nargs="*",
+        default=[],
+        help="Override opzionali dei parametri del modello (chiave=valore)",
+    )
+    p_predict.add_argument(
+        "--output",
+        help="File JSON su cui salvare input e predizione per ulteriori analisi",
+        default=None,
+    )
+
     return parser
 
 
@@ -346,6 +432,8 @@ def main() -> None:
         cmd_overfit(args)
     elif args.command == "evaluate":
         cmd_evaluate(args)
+    elif args.command == "predict":
+        cmd_predict(args)
     else:  # pragma: no cover - guardia difensiva
         raise ValueError(f"Comando sconosciuto: {args.command}")
 

--- a/src/tokenizer/tokenizer_io.py
+++ b/src/tokenizer/tokenizer_io.py
@@ -1,6 +1,48 @@
 """Utility wrappers around Hugging Face tokenizers used by NanoSocrates."""
 
+from __future__ import annotations
+
+import logging
+from typing import Iterable, Sequence
+
 from tokenizers import Tokenizer
+
+from src.utils.special_tokens import REQUIRED_SPECIAL_TOKENS
+
+LOGGER = logging.getLogger(__name__)
+
+
+def ensure_runtime_special_tokens(
+    tokenizer: Tokenizer,
+    required_tokens: Sequence[str] = REQUIRED_SPECIAL_TOKENS,
+) -> None:
+    """Ensure *required_tokens* exist in *tokenizer* at runtime.
+
+    When legacy vocabularies are missing freshly introduced markers we extend
+    them on the fly so training/evaluation remain backward compatible.
+    """
+
+    missing = [tok for tok in required_tokens if tokenizer.token_to_id(tok) is None]
+    if not missing:
+        return
+
+    added = 0
+    add_special = getattr(tokenizer, "add_special_tokens", None)
+    if callable(add_special):
+        added = add_special(list(missing))
+    else:
+        add_tokens = getattr(tokenizer, "add_tokens", None)
+        if callable(add_tokens):
+            added = add_tokens(list(missing))
+
+    if added:
+        LOGGER.debug("Added %s to tokenizer vocabulary", missing)
+
+    leftover = [tok for tok in missing if tokenizer.token_to_id(tok) is None]
+    if leftover:
+        LOGGER.warning(
+            "Unable to register special tokens %s in tokenizer vocabulary", leftover
+        )
 
 
 class TokWrapper:
@@ -8,6 +50,7 @@ class TokWrapper:
     def __init__(self, path: str) -> None:
         """Load the tokenizer from *path* and cache the pad token identifier."""
         self.tk = Tokenizer.from_file(path)
+        ensure_runtime_special_tokens(self.tk)
         # Cache the pad identifier once so downstream callers can access it even
         # if the tokenizer does not expose a dedicated property, and fail fast
         # when the vocabulary misses the mandatory <pad> symbol.
@@ -22,6 +65,16 @@ class TokWrapper:
     def token_to_id(self, tok: str) -> int | None:
         """Map *tok* to its integer id without exposing the underlying tokenizer."""
         return self.tk.token_to_id(tok)
+
+    def add_special_tokens(self, tokens: Iterable[str]) -> int:
+        """Proxy ``add_special_tokens`` so downstream utilities can reuse it."""
+
+        return self.tk.add_special_tokens(list(tokens))
+
+    def add_tokens(self, tokens: Iterable[str]) -> int:
+        """Proxy ``add_tokens`` keeping compatibility with the Tokenizer API."""
+
+        return self.tk.add_tokens(list(tokens))
 
     @property
     def pad_id(self) -> int:

--- a/src/training/dataloaders.py
+++ b/src/training/dataloaders.py
@@ -2,17 +2,25 @@
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from pathlib import Path
 import random
 import math
-from collections import Counter, defaultdict
+from collections import Counter, OrderedDict, defaultdict
 from typing import TYPE_CHECKING, Any, Dict, Iterable, Iterator, List, Mapping, Sequence
 
 import torch
 from torch.utils.data import DataLoader, Dataset, Sampler
 
 from src.utils.io import read_jsonl
+from src.utils.special_tokens import (
+    REQUIRED_SPECIAL_TOKENS,
+    RDF_LIST_SEPARATOR_TOKEN,
+    RDF_OBJECT_LIST_TOKEN,
+)
+
+LOGGER = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from tokenizers import Tokenizer
@@ -73,6 +81,43 @@ def _encode(tokenizer: Any, text: str) -> List[int]:
     if isinstance(encoded, (list, tuple)):
         return [int(tok) for tok in encoded]
     return list(encoded)
+
+
+def _token_to_id(tokenizer: Any, token: str) -> int | None:
+    """Safely resolve *token* to its integer id if present in the vocabulary."""
+
+    lookup = getattr(tokenizer, "token_to_id", None)
+    if callable(lookup):
+        token_id = lookup(token)
+        return int(token_id) if token_id is not None else None
+    return None
+
+
+def _ensure_special_tokens(tokenizer: Any) -> None:
+    """Ensure newly introduced special tokens exist in the loaded tokenizer."""
+
+    missing = [tok for tok in REQUIRED_SPECIAL_TOKENS if _token_to_id(tokenizer, tok) is None]
+    if not missing:
+        return
+
+    added = 0
+    add_special = getattr(tokenizer, "add_special_tokens", None)
+    if callable(add_special):
+        added = add_special(list(missing))
+    else:
+        add_tokens = getattr(tokenizer, "add_tokens", None)
+        if callable(add_tokens):
+            added = add_tokens(list(missing))
+
+    if added:
+        LOGGER.debug("Added runtime special tokens: %s", missing)
+
+    for token in missing:
+        if _token_to_id(tokenizer, token) is None:
+            raise ValueError(
+                "Tokenizer privo del token speciale richiesto '%s'. Aggiorna il vocabolario o rigenera il BPE."
+                % token
+            )
 
 
 @dataclass
@@ -154,6 +199,102 @@ def _normalise_span_payload(spans: Any) -> List[tuple[int, int]]:
     return normalised
 
 
+def _compact_rdf_input(text: str) -> str:
+    """Group repeated triples by subject/predicate to shorten RDF sequences."""
+
+    if not text or RDF_OBJECT_LIST_TOKEN in text:
+        return text
+
+    if "<SOT>" not in text or "<OBJ>" not in text:
+        return text
+
+    tokens = text.split()
+    prefix_tokens: List[str] = []
+    suffix_tokens: List[str] = []
+    groups: "OrderedDict[tuple[str, str], List[str]]" = OrderedDict()
+    order: List[tuple[str, str]] = []
+
+    i = 0
+    n = len(tokens)
+    while i < n and tokens[i] != "<SOT>":
+        prefix_tokens.append(tokens[i])
+        i += 1
+
+    while i < n:
+        if tokens[i] != "<SOT>":
+            suffix_tokens = tokens[i:]
+            break
+
+        i += 1
+        if i >= n or tokens[i] != "<SUBJ>":
+            return text
+        i += 1
+
+        subj_tokens: List[str] = []
+        while i < n and tokens[i] not in {"<PRED>", "<SOT>", "<EOT>"}:
+            subj_tokens.append(tokens[i])
+            i += 1
+        if i >= n or tokens[i] != "<PRED>":
+            return text
+        i += 1
+
+        pred_tokens: List[str] = []
+        while i < n and tokens[i] not in {"<OBJ>", "<SOT>", "<EOT>"}:
+            pred_tokens.append(tokens[i])
+            i += 1
+        if i >= n or tokens[i] != "<OBJ>":
+            return text
+        i += 1
+
+        obj_tokens: List[str] = []
+        while i < n and tokens[i] not in {"<EOT>", "<SOT>"}:
+            obj_tokens.append(tokens[i])
+            i += 1
+        if i >= n or tokens[i] != "<EOT>":
+            return text
+        i += 1
+
+        subj_text = " ".join(subj_tokens).strip()
+        pred_text = " ".join(pred_tokens).strip()
+        obj_text = " ".join(obj_tokens).strip()
+        key = (subj_text, pred_text)
+
+        if key not in groups:
+            groups[key] = []
+            order.append(key)
+        groups[key].append(obj_text)
+
+    if not any(len(values) > 1 for values in groups.values()):
+        return text
+
+    parts: List[str] = []
+    if prefix_tokens:
+        parts.append(" ".join(prefix_tokens))
+
+    for subj_text, pred_text in order:
+        objects = groups.get((subj_text, pred_text), [])
+        block: List[str] = ["<SOT>", "<SUBJ>"]
+        if subj_text:
+            block.append(subj_text)
+        block.append("<PRED>")
+        if pred_text:
+            block.append(pred_text)
+        if len(objects) > 1:
+            block.append(RDF_OBJECT_LIST_TOKEN)
+            block.append(f" {RDF_LIST_SEPARATOR_TOKEN} ".join(obj for obj in objects if obj))
+        else:
+            block.append("<OBJ>")
+            if objects:
+                block.append(objects[0])
+        block.append("<EOT>")
+        parts.append(" ".join(tok for tok in block if tok).strip())
+
+    if suffix_tokens:
+        parts.append(" ".join(suffix_tokens))
+
+    return " ".join(part for part in parts if part).strip()
+
+
 def _iter_examples(
     path: str,
     tokenizer: Any,
@@ -164,8 +305,21 @@ def _iter_examples(
 ) -> Iterator[Seq2SeqExample]:
     """Yield tokenised examples from a JSONL file."""
     inferred_task = _infer_task_from_path(path)
+    pad_id = _get_pad_id(tokenizer)
+    sot_id = _token_to_id(tokenizer, "<SOT>")
+    eot_id = _token_to_id(tokenizer, "<EOT>")
+    if sot_id is None:
+        fallback = eot_id if eot_id is not None else pad_id
+        if fallback is None:
+            raise ValueError("Tokenizer privo di token di avvio (<SOT>, <EOT> o <pad>).")
+        sot_id = int(fallback)
+    prefix_len = 1 if sot_id is not None else 0
+    suffix_len = 1 if eot_id is not None else 0
+    _ensure_special_tokens(tokenizer)
+
     for record in read_jsonl(path):
         source = str(record.get("input") or record.get("source") or record.get("text") or "")
+        source = _compact_rdf_input(source)
         target = str(record.get("target") or record.get("output") or record.get("label") or "")
         if not source or not target:
             continue
@@ -174,7 +328,16 @@ def _iter_examples(
         task_name = _normalise_task_name(task_hint, task_name)
 
         input_ids = _truncate(_encode(tokenizer, source), max_len)
-        label_ids = _truncate(_encode(tokenizer, target), max_len)
+        # Encode targets keeping room for start/end control tokens so the
+        # decoder receives the same prompts used during inference.
+        prefix: List[int] = [int(sot_id)] if sot_id is not None else []
+        suffix: List[int] = [int(eot_id)] if eot_id is not None else []
+
+        content_budget = max(0, max_len - prefix_len - suffix_len)
+        content_ids = _truncate(_encode(tokenizer, target), content_budget)
+        label_ids = prefix + content_ids
+        if suffix and len(label_ids) < max_len:
+            label_ids.extend(suffix[: max(0, max_len - len(label_ids))])
 
         mask_positions: List[int] | None = None
         mask_lengths: List[int] | None = None
@@ -186,12 +349,13 @@ def _iter_examples(
             )
             spans = _normalise_span_payload(raw_spans)
             if not spans and "<mask>" in source.lower():
-                spans = [(0, len(label_ids))] if label_ids else []
+                spans = [(0, len(content_ids))] if content_ids else []
 
             if spans:
                 valid_positions: List[int] = []
                 valid_lengths: List[int] = []
-                seq_len = len(label_ids)
+                offset = max(0, prefix_len - 1)
+                seq_len = len(content_ids)
                 for start, length in spans:
                     if length <= 0:
                         continue
@@ -203,7 +367,7 @@ def _iter_examples(
                     length = max(0, end - start)
                     if length == 0:
                         continue
-                    valid_positions.append(int(start))
+                    valid_positions.append(int(start + offset))
                     valid_lengths.append(int(length))
                 if valid_positions:
                     mask_positions = valid_positions

--- a/src/utils/special_tokens.py
+++ b/src/utils/special_tokens.py
@@ -1,0 +1,20 @@
+"""Centralised definitions for special tokens shared across modules."""
+
+from __future__ import annotations
+
+from typing import Tuple
+
+RDF_OBJECT_LIST_TOKEN: str = "<OBJ_LIST>"
+RDF_LIST_SEPARATOR_TOKEN: str = "|"
+
+# Expose an immutable tuple so callers can iterate without mutating globals.
+REQUIRED_SPECIAL_TOKENS: Tuple[str, ...] = (
+    RDF_OBJECT_LIST_TOKEN,
+    RDF_LIST_SEPARATOR_TOKEN,
+)
+
+__all__ = [
+    "RDF_OBJECT_LIST_TOKEN",
+    "RDF_LIST_SEPARATOR_TOKEN",
+    "REQUIRED_SPECIAL_TOKENS",
+]

--- a/tests/test_dataloaders_compaction.py
+++ b/tests/test_dataloaders_compaction.py
@@ -1,0 +1,31 @@
+from src.training import dataloaders
+
+
+def test_compact_rdf_input_groups_repeated_objects():
+    original = (
+        "<SOT> <SUBJ> dbr:Film <PRED> dbo:genre <OBJ> dbr:Doc <EOT> "
+        "<SOT> <SUBJ> dbr:Film <PRED> dbo:genre <OBJ> dbr:Drama <EOT> <RDF2Text>"
+    )
+    compacted = dataloaders._compact_rdf_input(original)
+    assert compacted.count("<SOT>") == 1
+    assert "<OBJ_LIST>" in compacted
+    assert "dbr:Doc | dbr:Drama" in compacted
+    assert compacted.strip().endswith("<RDF2Text>")
+
+
+def test_compact_rdf_input_preserves_singletons():
+    original = "<SOT> <SUBJ> dbr:Film <PRED> dbo:runtime <OBJ> 5400.0 <EOT> <RDF2Text>"
+    compacted = dataloaders._compact_rdf_input(original)
+    assert "<OBJ_LIST>" not in compacted
+    assert compacted == original
+
+
+def test_compact_rdf_input_keeps_mask_token():
+    original = (
+        "<SOT> <SUBJ> dbr:Film <PRED> dbo:starring <OBJ> dbr:Actor <EOT> "
+        "<SOT> <SUBJ> dbr:Film <PRED> dbo:starring <OBJ> <MASK> <EOT> <MASK>"
+    )
+    compacted = dataloaders._compact_rdf_input(original)
+    assert "<OBJ_LIST>" in compacted
+    assert "dbr:Actor | <MASK>" in compacted
+    assert compacted.strip().endswith("<MASK>")

--- a/tests/test_decoding_min_length.py
+++ b/tests/test_decoding_min_length.py
@@ -1,0 +1,55 @@
+import torch
+
+from src.decoding import base
+
+
+class DummyTokenizer:
+    def __init__(self):
+        self._vocab = {"<pad>": 0, "<SOT>": 1, "<EOT>": 2, "token": 3}
+        self.tk = self
+
+    @property
+    def pad_id(self):
+        return 0
+
+    def token_to_id(self, token: str):
+        return self._vocab.get(token)
+
+    def encode(self, text: str):
+        return [3]
+
+    def decode(self, ids):
+        return " ".join(str(i) for i in ids)
+
+
+class DummyModel:
+    def __init__(self, eot_id: int, fallback_id: int):
+        self.eot_id = eot_id
+        self.fallback_id = fallback_id
+
+    def eval(self):
+        return self
+
+    def __call__(self, inp, att, decoder_input_ids=None, **_):
+        step = decoder_input_ids.size(1)
+        vocab = 6
+        logits = torch.full((1, step, vocab), -1e3)
+        logits[:, -1, self.eot_id] = 10.0
+        logits[:, -1, self.fallback_id] = 9.0 - (step - 1)
+        return {"logits": logits}
+
+
+def test_greedy_decode_enforces_minimum_length():
+    tok = DummyTokenizer()
+    model = DummyModel(eot_id=2, fallback_id=3)
+    text, ids = base.decode_to_text(
+        model,
+        tok,
+        "<SOT>",
+        max_new_tokens=3,
+        device="cpu",
+        min_new_tokens=1,
+        return_ids=True,
+    )
+    assert ids[0] == tok.token_to_id("token")
+    assert text.startswith(str(tok.token_to_id("token")))

--- a/tests/test_evaluate_diagnostics.py
+++ b/tests/test_evaluate_diagnostics.py
@@ -1,0 +1,16 @@
+from src.eval import evaluate
+
+
+def test_summarise_lengths_empty_sequence():
+    stats = evaluate._summarise_lengths([])
+    assert stats == {"count": 0, "min": 0, "max": 0, "mean": 0.0, "median": 0.0, "zeros": 0}
+
+
+def test_summarise_lengths_basic_statistics():
+    stats = evaluate._summarise_lengths([0, 2, 4, 4])
+    assert stats["count"] == 4
+    assert stats["zeros"] == 1
+    assert stats["min"] == 0
+    assert stats["max"] == 4
+    assert stats["mean"] == 2.5
+    assert stats["median"] == 3.0

--- a/tests/test_run_predict.py
+++ b/tests/test_run_predict.py
@@ -1,0 +1,23 @@
+from src import run
+
+
+def test_prepare_predict_input_adds_marker():
+    result = run._prepare_predict_input("Hello", "text2rdf")
+    assert result.endswith(run.TASK_MARKERS["text2rdf"])
+
+
+def test_prepare_predict_input_keeps_existing_marker():
+    marker = run.TASK_MARKERS["rdf2text"]
+    text = f"Sample {marker}"
+    result = run._prepare_predict_input(text, "rdf2text")
+    assert result == text
+
+
+def test_prepare_predict_input_adds_mask_for_rdfcomp1():
+    result = run._prepare_predict_input("Subject predicate object", "rdfcomp1")
+    assert result.endswith("<MASK>")
+
+
+def test_prepare_predict_input_handles_none_task():
+    result = run._prepare_predict_input("  Hello world  ", None)
+    assert result == "Hello world"


### PR DESCRIPTION
## Summary
- group repetitive RDF triples into `<OBJ_LIST>` lists during dataset loading and add the required tokens at runtime
- expose generated token ids by default, enforce a minimum decoding length, and surface token ids in evaluate/predict outputs
- add reusable special token constants plus regression tests covering compaction and decoding behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ee9e2069f883318fc789da8ff3f03d