### PR TITLE
Add Hugging Face masked LM data utilities

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ pandas
 torch>=2.2
 tokenizers>=0.15
 numpy>=1.26
+transformers>=4.39
 wandb
 
 

--- a/src/model/losses.py
+++ b/src/model/losses.py
@@ -91,6 +91,31 @@ def _compute_span_accuracy(
     return float(correct_spans / total_spans) if total_spans > 0 else None
 
 
+@torch.inference_mode()
+def _compute_mask_token_accuracy(
+    logits: torch.Tensor, labels: torch.Tensor, ignore_index: int
+) -> Optional[float]:
+    """Compute token-level accuracy for masked language modelling targets.
+
+    When :class:`DataCollatorForLanguageModeling` is used, the labels tensor
+    contains the original token ids for masked positions and ``ignore_index``
+    (typically ``-100``) elsewhere. This helper measures the fraction of
+    correctly predicted masked tokens without requiring explicit span
+    annotations.
+    """
+
+    mask = (labels != ignore_index) & (labels >= 0)
+    if not torch.any(mask):
+        return None
+
+    predictions = logits.argmax(dim=-1)
+    correct = (predictions == labels) & mask
+    total = mask.sum().item()
+    if total == 0:
+        return None
+    return float(correct.sum().item() / total)
+
+
 def sequence_loss_with_span_metrics(
     logits: torch.Tensor,
     labels: torch.Tensor,
@@ -116,10 +141,17 @@ def sequence_loss_with_span_metrics(
     """
     logits_for_loss, target = _align_logits_and_labels(logits, labels)
 
+    target_for_loss = target
+    ignore_index = pad_id
+    if (target == -100).any():
+        ignore_index = -100
+        if pad_id != ignore_index:
+            target_for_loss = target_for_loss.masked_fill(target_for_loss == pad_id, ignore_index)
+
     loss = F.cross_entropy(
         logits_for_loss.reshape(-1, logits_for_loss.size(-1)),
-        target.reshape(-1),
-        ignore_index=pad_id,
+        target_for_loss.reshape(-1),
+        ignore_index=ignore_index,
     )
 
     metrics: Dict[str, float] = {}
@@ -127,6 +159,8 @@ def sequence_loss_with_span_metrics(
         accuracy = _compute_span_accuracy(
             logits_for_loss, target, mask_positions, mask_lengths
         )
+        if accuracy is None and ignore_index == -100:
+            accuracy = _compute_mask_token_accuracy(logits_for_loss, target, ignore_index)
         if accuracy is not None:
             metrics["mask_accuracy"] = accuracy
 

--- a/src/model/masked_lm.py
+++ b/src/model/masked_lm.py
@@ -1,0 +1,77 @@
+"""Wrapper utilities for Hugging Face masked language models."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import torch
+from torch import nn
+from transformers import AutoModelForMaskedLM, PreTrainedModel, PreTrainedTokenizerBase
+
+from src.utils.special_tokens import REQUIRED_SPECIAL_TOKENS
+
+
+def ensure_tokenizer_special_tokens(tokenizer: PreTrainedTokenizerBase) -> None:
+    """Ensure that project-specific markers exist in the provided tokenizer."""
+
+    vocab = tokenizer.get_vocab()
+    additional_tokens = [tok for tok in REQUIRED_SPECIAL_TOKENS if tok not in vocab]
+    if additional_tokens:
+        tokenizer.add_special_tokens({"additional_special_tokens": additional_tokens})
+
+
+class MaskedLMTaskModule(nn.Module):
+    """Thin wrapper around :class:`AutoModelForMaskedLM` with utility metrics."""
+
+    def __init__(
+        self,
+        model_name_or_path: str,
+        tokenizer: PreTrainedTokenizerBase,
+        *,
+        resize_token_embeddings: bool = True,
+        model_kwargs: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        super().__init__()
+        self.tokenizer = tokenizer
+        ensure_tokenizer_special_tokens(self.tokenizer)
+
+        kwargs = dict(model_kwargs or {})
+        self.model: PreTrainedModel = AutoModelForMaskedLM.from_pretrained(
+            model_name_or_path,
+            **kwargs,
+        )
+
+        if resize_token_embeddings:
+            self.model.resize_token_embeddings(len(self.tokenizer))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: torch.Tensor,
+        labels: Optional[torch.Tensor] = None,
+    ) -> Dict[str, Any]:
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            labels=labels,
+            return_dict=True,
+        )
+
+        result: Dict[str, Any] = {
+            "loss": outputs.loss,
+            "logits": outputs.logits,
+        }
+
+        if labels is not None and outputs.logits is not None:
+            with torch.no_grad():
+                mask = labels != -100
+                if torch.any(mask):
+                    predictions = outputs.logits.argmax(dim=-1)
+                    correct = ((predictions == labels) & mask).sum().item()
+                    total = mask.sum().item()
+                    result["metrics"] = {
+                        "mask_accuracy": float(correct / total) if total else 0.0
+                    }
+        return result
+
+*** End of File ***

--- a/src/training/mlm_datamodule.py
+++ b/src/training/mlm_datamodule.py
@@ -1,0 +1,128 @@
+"""Data utilities for masked language modeling using Hugging Face collators."""
+
+from __future__ import annotations
+
+from typing import List, Optional, Sequence
+
+from torch.utils.data import DataLoader, Dataset
+from transformers import DataCollatorForLanguageModeling, PreTrainedTokenizerBase
+
+from src.utils.special_tokens import REQUIRED_SPECIAL_TOKENS
+
+
+class MaskedTextDataset(Dataset):
+    """Dataset that tokenizes raw texts on-the-fly for MLM training."""
+
+    def __init__(
+        self,
+        texts: Sequence[str],
+        tokenizer: PreTrainedTokenizerBase,
+        max_length: int,
+    ) -> None:
+        filtered = [text for text in texts if text and text.strip()]
+        if not filtered:
+            raise ValueError("MaskedTextDataset requires at least one non-empty text")
+        self.examples: List[str] = filtered
+        self.tokenizer = tokenizer
+        self.max_length = int(max_length)
+
+    def __len__(self) -> int:
+        return len(self.examples)
+
+    def __getitem__(self, index: int) -> dict[str, List[int]]:
+        text = self.examples[index]
+        encoding = self.tokenizer(
+            text,
+            truncation=True,
+            max_length=self.max_length,
+            return_attention_mask=True,
+            add_special_tokens=True,
+        )
+        return {
+            "input_ids": encoding["input_ids"],
+            "attention_mask": encoding["attention_mask"],
+        }
+
+
+class MLMDataModule:
+    """Utility class that prepares DataLoaders for masked language modelling."""
+
+    def __init__(
+        self,
+        tokenizer: PreTrainedTokenizerBase,
+        train_texts: Sequence[str],
+        val_texts: Optional[Sequence[str]] = None,
+        *,
+        max_length: int = 256,
+        batch_size: int = 32,
+        mlm_probability: float = 0.15,
+        num_workers: int = 0,
+        shuffle: bool = True,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self.train_texts: List[str] = list(train_texts)
+        self.val_texts: Optional[List[str]] = list(val_texts) if val_texts is not None else None
+        self.max_length = int(max_length)
+        self.batch_size = int(batch_size)
+        self.mlm_probability = float(mlm_probability)
+        self.num_workers = int(num_workers)
+        self.shuffle = bool(shuffle)
+
+        self.data_collator: Optional[DataCollatorForLanguageModeling] = None
+        self.train_dataset: Optional[MaskedTextDataset] = None
+        self.val_dataset: Optional[MaskedTextDataset] = None
+
+    def _ensure_special_tokens(self) -> None:
+        vocab = self.tokenizer.get_vocab()
+        additional_tokens = [tok for tok in REQUIRED_SPECIAL_TOKENS if tok not in vocab]
+        if additional_tokens:
+            self.tokenizer.add_special_tokens({"additional_special_tokens": additional_tokens})
+
+    def setup(self) -> None:
+        """Initialise datasets and the masking collator."""
+
+        self._ensure_special_tokens()
+        self.data_collator = DataCollatorForLanguageModeling(
+            tokenizer=self.tokenizer,
+            mlm=True,
+            mlm_probability=self.mlm_probability,
+        )
+        self.train_dataset = MaskedTextDataset(
+            self.train_texts,
+            self.tokenizer,
+            max_length=self.max_length,
+        )
+        if self.val_texts is not None:
+            self.val_dataset = MaskedTextDataset(
+                self.val_texts,
+                self.tokenizer,
+                max_length=self.max_length,
+            )
+        else:
+            self.val_dataset = None
+
+    def train_dataloader(self) -> DataLoader:
+        if self.train_dataset is None or self.data_collator is None:
+            raise RuntimeError("setup() must be called before requesting a dataloader")
+        return DataLoader(
+            self.train_dataset,
+            batch_size=self.batch_size,
+            shuffle=self.shuffle,
+            num_workers=self.num_workers,
+            collate_fn=self.data_collator,
+        )
+
+    def val_dataloader(self) -> Optional[DataLoader]:
+        if self.val_dataset is None:
+            return None
+        if self.data_collator is None:
+            raise RuntimeError("setup() must be called before requesting a dataloader")
+        return DataLoader(
+            self.val_dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            num_workers=self.num_workers,
+            collate_fn=self.data_collator,
+        )
+
+*** End of File ***

--- a/src/utils/special_tokens.py
+++ b/src/utils/special_tokens.py
@@ -7,10 +7,20 @@ from typing import Tuple
 RDF_OBJECT_LIST_TOKEN: str = "<OBJ_LIST>"
 RDF_LIST_SEPARATOR_TOKEN: str = "|"
 
-# Expose an immutable tuple so callers can iterate without mutating globals.
+# Central list used to ensure that all task-specific markers are available
+# regardless of the tokenizer generation used at runtime.
 REQUIRED_SPECIAL_TOKENS: Tuple[str, ...] = (
+    "<SOT>",
+    "<EOT>",
+    "<SUBJ>",
+    "<PRED>",
+    "<OBJ>",
     RDF_OBJECT_LIST_TOKEN,
     RDF_LIST_SEPARATOR_TOKEN,
+    "<RDF2Text>",
+    "<Text2RDF>",
+    "<CONTINUERDF>",
+    "<MASK>",
 )
 
 __all__ = [


### PR DESCRIPTION
## Summary
- add the `transformers` dependency and expose all task-specific special tokens
- introduce helpers to wrap Hugging Face masked language models and compute mask accuracy
- provide a reusable masked-language-modeling datamodule that uses `DataCollatorForLanguageModeling`
- extend the loss utilities to support MLM-style labels while keeping the span metrics

## Testing
- pytest tests/training/test_loop.py -q

------
https://chatgpt.com/codex/tasks/task_e_68eed7fc93008331b9dd7034554e2704