### PR TITLE
Add datasets-backed JSONL datamodule and expose RDF compaction

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ tqdm
 regex 
 ujson 
 pandas
+datasets
 torch>=2.2
 tokenizers>=0.15
 numpy>=1.26

--- a/src/training/dataloaders.py
+++ b/src/training/dataloaders.py
@@ -172,7 +172,7 @@ def _normalise_span_payload(spans: Any) -> List[tuple[int, int]]:
     return normalised
 
 
-def _compact_rdf_input(text: str) -> str:
+def compact_rdf(text: str) -> str:
     """Group repeated triples by subject/predicate to shorten RDF sequences."""
 
     if not text or RDF_OBJECT_LIST_TOKEN in text:
@@ -290,7 +290,7 @@ def _iter_examples(
     suffix_len = 1 if eot_id is not None else 0
     for record in read_jsonl(path):
         source = str(record.get("input") or record.get("source") or record.get("text") or "")
-        source = _compact_rdf_input(source)
+        source = compact_rdf(source)
         target = str(record.get("target") or record.get("output") or record.get("label") or "")
         if not source or not target:
             continue

--- a/src/training/datamodule.py
+++ b/src/training/datamodule.py
@@ -1,0 +1,234 @@
+"""Data loading utilities built on top of the 🤗 datasets library."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping, Sequence
+from typing import Any, Dict, Iterable, List, Optional
+
+from datasets import DatasetDict, load_dataset
+from torch.utils.data import DataLoader
+
+from src.training.dataloaders import PadCollator, compact_rdf
+
+LOGGER = logging.getLogger(__name__)
+
+
+class JSONLSeq2SeqDataModule:
+    """Load JSON Lines files with :mod:`datasets` and prepare PyTorch loaders."""
+
+    def __init__(
+        self,
+        tokenizer: Any,
+        data_files: Mapping[str, str],
+        *,
+        batch_size: int = 8,
+        max_input_length: int = 512,
+        max_target_length: int = 128,
+        num_workers: int = 0,
+        task_name: str | None = None,
+        shuffle_train: bool = True,
+    ) -> None:
+        if "train" not in data_files or "validation" not in data_files:
+            raise ValueError("'data_files' deve contenere le chiavi 'train' e 'validation'.")
+
+        self.tokenizer = tokenizer
+        self.data_files = dict(data_files)
+        self.batch_size = int(batch_size)
+        self.max_input_length = int(max_input_length)
+        self.max_target_length = int(max_target_length)
+        self.num_workers = int(num_workers)
+        self.task_name = str(task_name or "generic")
+        self.shuffle_train = bool(shuffle_train)
+
+        self.pad_id: Optional[int] = None
+        self.sot_id: Optional[int] = None
+        self.eot_id: Optional[int] = None
+
+        self._label_prefix: List[int] = []
+        self._label_suffix: List[int] = []
+
+        self.processed_dataset: DatasetDict | None = None
+        self.train_dataset = None
+        self.val_dataset = None
+
+    # ------------------------------------------------------------------ utils
+    def _get_token_id(self, token: str) -> Optional[int]:
+        lookup = getattr(self.tokenizer, "token_to_id", None)
+        if callable(lookup):
+            token_id = lookup(token)
+            return int(token_id) if token_id is not None else None
+        return None
+
+    def _resolve_pad_id(self) -> int:
+        if hasattr(self.tokenizer, "pad_id") and getattr(self.tokenizer, "pad_id") is not None:
+            return int(getattr(self.tokenizer, "pad_id"))
+        pad_id = self._get_token_id("<pad>")
+        if pad_id is None:
+            raise ValueError("Tokenizer privo di <pad>: rigenera il BPE includendo <pad>.")
+        return pad_id
+
+    @staticmethod
+    def _encode_object(encoded: Any) -> List[int]:
+        if hasattr(encoded, "ids"):
+            return [int(tok) for tok in encoded.ids]
+        if isinstance(encoded, (list, tuple)):
+            return [int(tok) for tok in encoded]
+        return [int(tok) for tok in encoded]
+
+    def _encode_batch(self, texts: Sequence[str], max_len: int) -> List[List[int]]:
+        if not texts:
+            return []
+        encode_batch = getattr(self.tokenizer, "encode_batch", None)
+        if callable(encode_batch):
+            encodings = encode_batch(list(texts))
+            sequences = [self._encode_object(enc)[:max_len] for enc in encodings]
+        else:
+            encode = getattr(self.tokenizer, "encode")
+            sequences = [self._encode_object(encode(text))[:max_len] for text in texts]
+        return sequences
+
+    def _encode_targets(self, targets: Sequence[str]) -> List[List[int]]:
+        prefix = list(self._label_prefix)
+        suffix = list(self._label_suffix)
+        content_budget = max(0, self.max_target_length - len(prefix) - len(suffix))
+
+        content_sequences = self._encode_batch(targets, content_budget)
+        processed: List[List[int]] = []
+        for content in content_sequences:
+            label = prefix + content
+            if suffix and len(label) < self.max_target_length:
+                needed = min(len(suffix), self.max_target_length - len(label))
+                label.extend(suffix[:needed])
+            processed.append(label)
+        return processed
+
+    @staticmethod
+    def _columns_to_remove(dataset: DatasetDict) -> List[str]:
+        keep = {"film", "task"}
+        columns: set[str] = set()
+        for split in dataset.keys():
+            columns.update(dataset[split].column_names)
+        return sorted(col for col in columns if col not in keep)
+
+    @staticmethod
+    def _normalise_task(value: Any, fallback: str) -> str:
+        if value is None:
+            return fallback
+        text = str(value).strip()
+        return text if text else fallback
+
+    @staticmethod
+    def _extract_sources(batch: Mapping[str, Sequence[Any]]) -> Sequence[str]:
+        for key in ("input", "source", "text"):
+            if key in batch:
+                return batch[key]
+        return []
+
+    @staticmethod
+    def _extract_targets(batch: Mapping[str, Sequence[Any]]) -> Sequence[str]:
+        for key in ("target", "output", "label"):
+            if key in batch:
+                return batch[key]
+        return []
+
+    @staticmethod
+    def _has_valid_pair(example: Mapping[str, Any]) -> bool:
+        source = (
+            example.get("input")
+            or example.get("source")
+            or example.get("text")
+            or ""
+        )
+        target = (
+            example.get("target")
+            or example.get("output")
+            or example.get("label")
+            or ""
+        )
+        return bool(str(source).strip()) and bool(str(target).strip())
+
+    # ----------------------------------------------------------------- dataset
+    def setup(self, stage: str | None = None) -> None:
+        """Materialise and preprocess the dataset splits."""
+
+        raw_dataset = load_dataset("json", data_files=self.data_files)
+        raw_dataset = raw_dataset.filter(self._has_valid_pair)
+
+        self.pad_id = self._resolve_pad_id()
+        self.sot_id = self._get_token_id("<SOT>")
+        self.eot_id = self._get_token_id("<EOT>")
+        self._label_prefix = [int(self.sot_id)] if self.sot_id is not None else []
+        self._label_suffix = [int(self.eot_id)] if self.eot_id is not None else []
+
+        remove_columns = self._columns_to_remove(raw_dataset)
+
+        def preprocess_function(batch: Mapping[str, Sequence[Any]]) -> Dict[str, Iterable[Any]]:
+            raw_sources = self._extract_sources(batch)
+            raw_targets = self._extract_targets(batch)
+            if len(raw_sources) != len(raw_targets):
+                raise ValueError("Numero di input e target incoerente nel batch.")
+
+            compact_inputs = [compact_rdf(str(src or "")) for src in raw_sources]
+            targets = [str(tgt or "") for tgt in raw_targets]
+
+            model_inputs: Dict[str, Iterable[Any]] = {
+                "input_ids": self._encode_batch(compact_inputs, self.max_input_length),
+                "labels": self._encode_targets(targets),
+                "raw_input": compact_inputs,
+                "raw_target": targets,
+            }
+
+            tasks = batch.get("task")
+            if tasks is not None:
+                model_inputs["task"] = [self._normalise_task(task, self.task_name) for task in tasks]
+            else:
+                model_inputs["task"] = [self.task_name] * len(compact_inputs)
+
+            films = batch.get("film")
+            if films is not None:
+                model_inputs["film"] = [str(film) if film is not None else None for film in films]
+
+            return model_inputs
+
+        processed_dataset = raw_dataset.map(
+            preprocess_function,
+            batched=True,
+            remove_columns=remove_columns,
+        )
+
+        self.processed_dataset = processed_dataset
+        self.train_dataset = processed_dataset.get("train")
+        self.val_dataset = processed_dataset.get("validation")
+
+        LOGGER.info(
+            "Dataset caricato: train=%d, validation=%d",
+            len(self.train_dataset) if self.train_dataset is not None else 0,
+            len(self.val_dataset) if self.val_dataset is not None else 0,
+        )
+
+    # --------------------------------------------------------------- dataloader
+    def _build_dataloader(self, dataset, *, shuffle: bool) -> DataLoader:
+        if dataset is None:
+            raise RuntimeError("setup() deve essere chiamato prima di creare i dataloader.")
+        if self.pad_id is None:
+            raise RuntimeError("Impossibile costruire il dataloader senza pad_id valido.")
+
+        collate = PadCollator(pad_id=self.pad_id)
+        return DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=shuffle,
+            collate_fn=collate,
+            num_workers=self.num_workers,
+        )
+
+    def train_dataloader(self) -> DataLoader:
+        """Return the DataLoader for the training split."""
+
+        return self._build_dataloader(self.train_dataset, shuffle=self.shuffle_train)
+
+    def val_dataloader(self) -> DataLoader:
+        """Return the DataLoader for the validation split."""
+
+        return self._build_dataloader(self.val_dataset, shuffle=False)

--- a/tests/fixtures/toy_data_train.jsonl
+++ b/tests/fixtures/toy_data_train.jsonl
@@ -1,0 +1,2 @@
+{"input": "<SOT> <SUBJ> dbr:FilmA <PRED> dbo:genre <OBJ> dbr:Comedy <EOT> <SOT> <SUBJ> dbr:FilmA <PRED> dbo:genre <OBJ> dbr:Drama <EOT>", "target": "A comedy drama.", "task": "rdf2text", "film": "dbr:FilmA"}
+{"input": "<SOT> <SUBJ> dbr:FilmB <PRED> dbo:runtime <OBJ> 5400.0 <EOT>", "target": "Runtime is 90 minutes.", "task": "rdf2text", "film": "dbr:FilmB"}

--- a/tests/fixtures/toy_data_val.jsonl
+++ b/tests/fixtures/toy_data_val.jsonl
@@ -1,0 +1,1 @@
+{"input": "<SOT> <SUBJ> dbr:FilmC <PRED> dbo:starring <OBJ> dbr:Actor1 <EOT>", "target": "Starring Actor1.", "task": "rdf2text", "film": "dbr:FilmC"}

--- a/tests/test_dataloaders_compaction.py
+++ b/tests/test_dataloaders_compaction.py
@@ -6,7 +6,7 @@ def test_compact_rdf_input_groups_repeated_objects():
         "<SOT> <SUBJ> dbr:Film <PRED> dbo:genre <OBJ> dbr:Doc <EOT> "
         "<SOT> <SUBJ> dbr:Film <PRED> dbo:genre <OBJ> dbr:Drama <EOT> <RDF2Text>"
     )
-    compacted = dataloaders._compact_rdf_input(original)
+    compacted = dataloaders.compact_rdf(original)
     assert compacted.count("<SOT>") == 1
     assert "<OBJ_LIST>" in compacted
     assert "dbr:Doc | dbr:Drama" in compacted
@@ -15,7 +15,7 @@ def test_compact_rdf_input_groups_repeated_objects():
 
 def test_compact_rdf_input_preserves_singletons():
     original = "<SOT> <SUBJ> dbr:Film <PRED> dbo:runtime <OBJ> 5400.0 <EOT> <RDF2Text>"
-    compacted = dataloaders._compact_rdf_input(original)
+    compacted = dataloaders.compact_rdf(original)
     assert "<OBJ_LIST>" not in compacted
     assert compacted == original
 
@@ -25,7 +25,7 @@ def test_compact_rdf_input_keeps_mask_token():
         "<SOT> <SUBJ> dbr:Film <PRED> dbo:starring <OBJ> dbr:Actor <EOT> "
         "<SOT> <SUBJ> dbr:Film <PRED> dbo:starring <OBJ> <MASK> <EOT> <MASK>"
     )
-    compacted = dataloaders._compact_rdf_input(original)
+    compacted = dataloaders.compact_rdf(original)
     assert "<OBJ_LIST>" in compacted
     assert "dbr:Actor | <MASK>" in compacted
     assert compacted.strip().endswith("<MASK>")

--- a/tests/training/test_datamodule.py
+++ b/tests/training/test_datamodule.py
@@ -1,0 +1,39 @@
+import pathlib
+import sys
+
+from tokenizers import Tokenizer
+
+PROJECT_ROOT = pathlib.Path(__file__).resolve().parents[2]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.training.datamodule import JSONLSeq2SeqDataModule
+
+
+def test_jsonl_datamodule_compacts_and_tokenizes():
+    tokenizer = Tokenizer.from_file(str(PROJECT_ROOT / "data" / "vocab" / "bpe.json"))
+    data_files = {
+        "train": str(PROJECT_ROOT / "tests" / "fixtures" / "toy_data_train.jsonl"),
+        "validation": str(PROJECT_ROOT / "tests" / "fixtures" / "toy_data_val.jsonl"),
+    }
+
+    module = JSONLSeq2SeqDataModule(
+        tokenizer=tokenizer,
+        data_files=data_files,
+        batch_size=2,
+        max_input_length=64,
+        max_target_length=32,
+        shuffle_train=False,
+    )
+    module.setup()
+
+    assert module.train_dataset is not None
+    assert module.val_dataset is not None
+    assert len(module.train_dataset) == 2
+    assert len(module.val_dataset) == 1
+
+    batch = next(iter(module.train_dataloader()))
+    assert batch["input_ids"].shape[0] == 2
+    assert any("<OBJ_LIST>" in text for text in batch["raw_input"])
+    assert all(task == "rdf2text" for task in batch["tasks"])
+    assert batch["labels"].shape[1] <= 32


### PR DESCRIPTION
## Summary
- expose the RDF compaction helper and cover it with updated tests
- add a JSONLSeq2SeqDataModule that loads and tokenises data via the `datasets` library
- bundle toy JSONL fixtures and declare the new dependency in requirements

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eed83e516c83319901cface71552be