### PR TITLE
Add torchmetrics metrics and configurable generation parameters

### DIFF
--- a/configs/eval/multitask_default.yaml
+++ b/configs/eval/multitask_default.yaml
@@ -8,8 +8,10 @@ num_workers: 2
 device: "cuda"
 output_json: "reports/multitask_default_eval.json"
 
-decoding:
+generation_params:
   max_new_tokens: 512
+  min_new_tokens: 1
+  debug_generation: false
 
 # abilita la valutazione delle maschere quando il checkpoint le supporta
 enable_entity_spans: false

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,5 +9,6 @@ torch>=2.2
 tokenizers>=0.15
 numpy>=1.26
 wandb
+torchmetrics
 
 

--- a/src/decoding/base.py
+++ b/src/decoding/base.py
@@ -57,6 +57,7 @@ def greedy_decode(
     min_new_tokens: int = 1,
     debug: bool = False,
     forbidden_token_ids: Optional[Sequence[int]] = None,
+    **unused_generation_kwargs,
 ):
     """Esegue il decoding greedy restituendo gli ID generati.
 
@@ -81,6 +82,12 @@ def greedy_decode(
         for token_id in (forbidden_token_ids or [])
         if token_id is not None
     )
+
+    if unused_generation_kwargs:
+        LOGGER.debug(
+            "[decode] ignoring unsupported generation kwargs: %s",
+            sorted(unused_generation_kwargs),
+        )
 
     for step in range(max_new_tokens):
         out = model(inp, att, decoder_input_ids=y)

--- a/src/eval/evaluate.py
+++ b/src/eval/evaluate.py
@@ -8,7 +8,7 @@ import os
 from collections import Counter, defaultdict
 from functools import partial
 from pathlib import Path
-from typing import Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
+from typing import Any, Dict, Iterable, List, Mapping, MutableMapping, Optional, Sequence, Tuple
 
 from pyparsing import Diagnostics
 import torch
@@ -53,6 +53,56 @@ def _normalise_text(text: str) -> str:
         return ""
     cleaned = [tok for tok in text.replace("\n", " ").split() if tok and tok != "<pad>"]
     return " ".join(cleaned).strip()
+
+
+def _to_int(value: Any, default: int) -> int:
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return default
+
+
+def _to_bool(value: Any, default: bool = False) -> bool:
+    if isinstance(value, str):
+        return value.lower() not in {"false", "0", "no"}
+    if value is None:
+        return default
+    return bool(value)
+
+
+def _prepare_generation_params(
+    config: Mapping[str, object], default_max_len: int
+) -> tuple[int, int, bool, Dict[str, object]]:
+    """Merge generation settings from legacy ``decoding`` and new configs."""
+
+    params: Dict[str, object] = {}
+
+    legacy_decoding = config.get("decoding")
+    if isinstance(legacy_decoding, Mapping):
+        params.update(legacy_decoding)
+
+    # Allow nested ``model.generation_params`` or top-level ``generation_params``.
+    direct_params = config.get("generation_params")
+    if isinstance(direct_params, Mapping):
+        params.update(direct_params)
+    model_cfg = config.get("model")
+    if isinstance(model_cfg, Mapping):
+        nested_params = model_cfg.get("generation_params")
+        if isinstance(nested_params, Mapping):
+            params.update(nested_params)
+
+    max_tokens = params.pop("max_new_tokens", params.pop("max_length", default_max_len))
+    min_tokens = params.pop("min_new_tokens", params.pop("min_length", 1))
+    debug_raw = params.pop(
+        "debug_generation",
+        params.pop("debug_token_ids", params.pop("debug", False)),
+    )
+
+    max_new_tokens = _to_int(max_tokens, default_max_len)
+    min_new_tokens = max(0, _to_int(min_tokens, 1))
+    debug_generation = _to_bool(debug_raw, False)
+
+    return max_new_tokens, min_new_tokens, debug_generation, dict(params)
 
 
 def _summarise_lengths(lengths: Iterable[int]) -> Dict[str, float]:
@@ -186,6 +236,7 @@ def _generate_predictions(
     normalise: bool = True,
     return_raw: bool = False,
     debug_generation: bool = False,
+    generation_params: Mapping[str, object] | None = None,
 ) -> (
     tuple[List[str], List[str], List[str]]
     | tuple[List[str], List[str], List[str], List[str], List[str], List[List[int]]]
@@ -214,6 +265,20 @@ def _generate_predictions(
         base_forbidden_ids = tuple(
             dict.fromkeys(structural_token_ids + (int(pad_token_id),))
         )
+
+    extra_generation_kwargs = dict(generation_params or {})
+    for blocked_key in {
+        "max_new_tokens",
+        "max_length",
+        "min_new_tokens",
+        "min_length",
+        "debug_generation",
+        "debug",
+        "return_ids",
+        "device",
+        "forbidden_token_ids",
+    }:
+        extra_generation_kwargs.pop(blocked_key, None)
 
     for ex in dataset.items:
         source: str = ""
@@ -263,6 +328,7 @@ def _generate_predictions(
             debug=debug_generation,
             return_ids=True,
             forbidden_token_ids=forbidden_ids,
+            **extra_generation_kwargs,
         )
         raw_predictions.append(pred)
         raw_references.append(target)
@@ -477,21 +543,12 @@ def evaluate_from_config(config: Mapping[str, object]) -> Dict[str, object]:
     )
 
     max_len = int(config.get("max_len", saved_cfg.get("max_len", 256)))
-    decode_cfg = config.get("decoding") or {}
-    max_new_tokens = int(decode_cfg.get("max_new_tokens", max_len))
-    min_new_tokens_raw = decode_cfg.get("min_new_tokens", 1)
-    try:
-        min_new_tokens = max(0, int(min_new_tokens_raw))
-    except (TypeError, ValueError):
-        min_new_tokens = 1
-    debug_generation_raw = decode_cfg.get(
-        "debug_generation",
-        decode_cfg.get("debug_token_ids", decode_cfg.get("debug", False)),
-    )
-    if isinstance(debug_generation_raw, str):
-        debug_generation = debug_generation_raw.lower() not in {"false", "0", "no"}
-    else:
-        debug_generation = bool(debug_generation_raw)
+    (
+        max_new_tokens,
+        min_new_tokens,
+        debug_generation,
+        extra_generation_kwargs,
+    ) = _prepare_generation_params(config, max_len)
 
     preview_cfg = config.get("preview") or {}
     preview_limit_raw = preview_cfg.get("limit", config.get("preview_samples", 0))
@@ -575,6 +632,7 @@ def evaluate_from_config(config: Mapping[str, object]) -> Dict[str, object]:
                     min_new_tokens,
                     return_raw=True,
                     debug_generation=debug_generation,
+                    generation_params=extra_generation_kwargs,
                 )
             else:
                 preds, refs, task_tags = _generate_predictions(
@@ -586,6 +644,7 @@ def evaluate_from_config(config: Mapping[str, object]) -> Dict[str, object]:
                     min_new_tokens,
                     return_raw=False,
                     debug_generation=debug_generation,
+                    generation_params=extra_generation_kwargs,
                 )
                 raw_preds = preds
                 token_ids = [[] for _ in preds]

--- a/src/eval/metrics.py
+++ b/src/eval/metrics.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 import math
 from collections import Counter
-from typing import Iterable, List, Sequence, Tuple
+from typing import Callable, Iterable, List, Sequence, Tuple
+
+import torch
+from torchmetrics import MetricCollection
+from torchmetrics.metric import Metric
+from torchmetrics.text.rouge import ROUGEScore
 
 from src.data.serialization import parse_rdf
 
@@ -24,6 +29,55 @@ def _ngram_counts(tokens: Sequence[str], n: int) -> Counter:
     if n <= 0:
         return Counter()
     return Counter(tuple(tokens[i : i + n]) for i in range(len(tokens) - n + 1))
+
+
+# ---------------------------------------------------------------------------
+# Torchmetrics helpers
+# ---------------------------------------------------------------------------
+
+
+class _PairwiseMetric(Metric):
+    """Torchmetrics wrapper that aggregates predictions before computing."""
+
+    is_differentiable = False
+    full_state_update = True
+
+    def __init__(self, fn: Callable[[Sequence[str], Sequence[str]], float]):
+        super().__init__(compute_on_cpu=True)
+        self._fn = fn
+        self.add_state("predictions", default=[], dist_reduce_fx=None)
+        self.add_state("references", default=[], dist_reduce_fx=None)
+
+    def update(self, predictions: Sequence[str], references: Sequence[str]) -> None:  # type: ignore[override]
+        preds = ["" if p is None else str(p) for p in predictions]
+        refs = ["" if r is None else str(r) for r in references]
+        if len(preds) != len(refs):
+            raise ValueError("predictions e references devono avere la stessa lunghezza")
+        self.predictions.extend(preds)
+        self.references.extend(refs)
+
+    def compute(self) -> torch.Tensor:  # type: ignore[override]
+        value = float(self._fn(self.predictions, self.references)) if self.predictions else 0.0
+        return torch.tensor(value, dtype=torch.float32)
+
+
+class RougeLMetric(ROUGEScore):
+    """Specialised ROUGE metric that returns the F-measure in percentage."""
+
+    def __init__(self) -> None:
+        super().__init__(rouge_keys=("rougeL",), use_stemmer=False)
+
+    def compute(self) -> torch.Tensor:  # type: ignore[override]
+        scores = super().compute()
+        if isinstance(scores, dict):
+            value = scores.get("rougeL_fmeasure")
+        else:
+            value = scores
+        if value is None:
+            return torch.tensor(0.0, dtype=torch.float32)
+        if not torch.is_tensor(value):
+            value = torch.tensor(float(value), dtype=torch.float32)
+        return value * 100
 
 
 # ---------------------------------------------------------------------------
@@ -201,6 +255,15 @@ def meteor_score(predictions: Sequence[str], references: Sequence[str]) -> float
     return float(sum(scores) / len(scores) * 100)
 
 
+_TEXT_GENERATION_METRICS = MetricCollection(
+    {
+        "bleu": _PairwiseMetric(corpus_bleu),
+        "rouge_l": RougeLMetric(),
+        "meteor": _PairwiseMetric(meteor_score),
+    }
+)
+
+
 # ---------------------------------------------------------------------------
 # Triple RDF e accuracy
 # ---------------------------------------------------------------------------
@@ -269,11 +332,10 @@ def compute_text_generation_metrics(
     predictions: Sequence[str], references: Sequence[str]
 ) -> dict:
     """Return a dictionary with BLEU, ROUGE-L and METEOR scores."""
-    return {
-        "bleu": corpus_bleu(predictions, references),
-        "rouge_l": rouge_l_score(predictions, references),
-        "meteor": meteor_score(predictions, references),
-    }
+    metrics = _TEXT_GENERATION_METRICS.clone()
+    metrics.update(predictions, references)
+    computed = metrics.compute()
+    return {name: float(value.cpu().item()) for name, value in computed.items()}
 
 
 def compute_triple_metrics(


### PR DESCRIPTION
## Summary
- replace the manual text-generation metric aggregation with a `torchmetrics.MetricCollection`, exposing BLEU, ROUGE-L and METEOR through reusable metric objects
- allow evaluation configs to define `generation_params` (including nested under `model`) and forward any extra generation kwargs to the decoder while ignoring unsupported ones
- add the `torchmetrics` dependency and make the greedy decoder robust to optional generation kwargs so tuning does not require code changes

## Testing
- PYTHONPATH=. pytest tests/test_decoding_min_length.py tests/test_evaluate_diagnostics.py

------
https://chatgpt.com/codex/tasks/task_e_68eed8a0f3c48331b3ba023dac812397