### PR TITLE
Fix metric aggregation and restore task-weighted training

### DIFF
--- a/src/run.py
+++ b/src/run.py
@@ -15,6 +15,7 @@ from tokenizers import Tokenizer
 from src.data.builders import build_and_cache_datasets
 from src.model.transformer import TinySeq2Seq
 from src.tokenizer.tokenizer_io import ensure_runtime_special_tokens
+from src.training.dataloaders import create_multitask_dataloader
 from src.training.simple_training import build_dataloader, evaluate_model, train_one_epoch
 from src.utils.config import (
     add_common_overrides,
@@ -128,17 +129,28 @@ def run_training(cfg: Dict[str, Any]) -> None:
     train_dataset = datasets["train"]
     val_dataset = datasets.get("validation")
     test_dataset = datasets.get("test")
+    ratios = datasets.get("ratios") or {}
     pad_id = _pad_id(tokenizer)
 
     batch_size = int(cfg.get("batch_size", 16))
     num_workers = int(cfg.get("num_workers", 0))
-    train_loader = build_dataloader(
-        train_dataset,
-        tokenizer,
-        batch_size=batch_size,
-        shuffle=True,
-        num_workers=num_workers,
-    )
+    if ratios:
+        train_loader = create_multitask_dataloader(
+            train_dataset,
+            tokenizer=tokenizer,
+            batch_size=batch_size,
+            ratios=ratios,
+            num_workers=num_workers,
+            shuffle=True,
+        )
+    else:
+        train_loader = build_dataloader(
+            train_dataset,
+            tokenizer,
+            batch_size=batch_size,
+            shuffle=True,
+            num_workers=num_workers,
+        )
     val_loader = (
         build_dataloader(val_dataset, tokenizer, batch_size=batch_size, shuffle=False, num_workers=num_workers)
         if val_dataset

--- a/src/training/simple_training.py
+++ b/src/training/simple_training.py
@@ -66,6 +66,7 @@ def train_one_epoch(
     total_loss = 0.0
     total_exact = 0.0
     total_batches = 0
+    total_examples = 0
     pending = 0
 
     for batch in loader:
@@ -79,9 +80,12 @@ def train_one_epoch(
         if loss is None:
             raise ValueError("Il modello deve restituire una loss per addestrare.")
 
-        total_loss += float(loss.detach().item())
-        total_exact += float(outputs.get("metrics", {}).get("exact_match", 0.0))
+        batch_size = len(batch["input_ids"])
+
+        total_loss += float(loss.detach().item()) * batch_size
+        total_exact += float(outputs.get("metrics", {}).get("exact_match", 0.0)) * batch_size
         total_batches += 1
+        total_examples += batch_size
 
         (loss / max(1, grad_accum_steps)).backward()
         pending += 1
@@ -99,7 +103,7 @@ def train_one_epoch(
         optimizer.step()
         optimizer.zero_grad()
 
-    denom = max(1, total_batches)
+    denom = max(1, total_examples)
     return {
         "loss": total_loss / denom,
         "exact_match": total_exact / denom,
@@ -138,6 +142,7 @@ def evaluate_model(
     total_loss = 0.0
     total_exact = 0.0
     total_batches = 0
+    total_examples = 0
     per_task: Dict[str, list[float]] = defaultdict(list)
 
     with torch.no_grad():
@@ -153,9 +158,12 @@ def evaluate_model(
             if loss is None:
                 raise ValueError("Il modello deve restituire una loss in valutazione.")
 
-            total_loss += float(loss.item())
-            total_exact += float(outputs.get("metrics", {}).get("exact_match", 0.0))
+            batch_size = len(batch["input_ids"])
+
+            total_loss += float(loss.item()) * batch_size
+            total_exact += float(outputs.get("metrics", {}).get("exact_match", 0.0)) * batch_size
             total_batches += 1
+            total_examples += batch_size
 
             logits = outputs.get("logits")
             tasks: Iterable[str] = batch.get("tasks") or []
@@ -164,7 +172,7 @@ def evaluate_model(
                 for index, task in enumerate(tasks):
                     per_task[task].append(float(per_example[index].item()))
 
-    denom = max(1, total_batches)
+    denom = max(1, total_examples)
     summary: Dict[str, object] = {
         "loss": total_loss / denom,
         "exact_match": total_exact / denom,


### PR DESCRIPTION
## Summary
- replace the previous CLI with a compact train/evaluate pipeline that loads data, builds the model, and saves the best checkpoint
- add a lightweight training utility module that provides basic dataloaders plus train/eval helpers with optional task breakdowns
- extend dataset construction to surface optional test splits alongside train/validation data
- weight training/evaluation metrics by sampled examples and restore task-weighted sampling in the CLI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f0a02bc5308331bc2e8c2c6172eeaf